### PR TITLE
make macro arguments not clickable

### DIFF
--- a/frontend/clean.css
+++ b/frontend/clean.css
@@ -7,7 +7,7 @@
 	font-weight: bold;
 }
 
-.funcname.funcname-onlyused {
+.funcname.funcname-onlyused, .macroargument{
 	color: #6e94ad;
 	font-weight: normal;
 }

--- a/frontend/clean.js
+++ b/frontend/clean.js
@@ -289,7 +289,7 @@ function highlightMacro(macro, callback, start) {
 		args: [
 			[/(\s+)/,        ['whitespace']],
 			[/(:==)/,        ['punctuation'], 'rhs'],
-			[/(\S+)/,        ['funcname funcname-onlyused']]
+			[/(\S+)/,        ['macroargument']]
 		],
 		rhs: [
 			[/(\s+)/,        ['whitespace']],


### PR DESCRIPTION
identifiers in the macro expansion can mean something and should therefore stay clickable(or fully parsed). However, the macro arguments mean nothing and should thus not be clickable.
