### PR TITLE
Fix rare checkbox error

### DIFF
--- a/frontend/api.js
+++ b/frontend/api.js
@@ -402,7 +402,7 @@ function formsubmit() {
 };
 
 advanced_checkbox.onchange = function () {
-	toggle('advanced');
+	this.style.display = this.checked ? 'block' : 'none';
 }
 
 window.onload = function () {


### PR DESCRIPTION
Sometimes when the browser loads the page from cache the state of the
advanced checkbox is inversed. This fixes such cases.