### PR TITLE
New interface for builtins, core libraries, and ObjectIO

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ JSON request with at least one of the following fields:
 * `typeName`, the name of the type to search for.
 * `libraries`, a list of names of libraries to search in.
 * `include_builtins`, a boolean, whether language builtins should be searched or not.
+* `include_core`, a boolean, whether library cores should be searched or not.
 * `modules`, a list of names of modules to search in.
 * `page`: 0 for the first *n* results, 1 for the next *n*, etc.
 

--- a/README.md
+++ b/README.md
@@ -127,9 +127,8 @@ JSON request with at least one of the following fields:
 * `name`, the name of the function to search for.
 * `className`, the name of the class to search for.
 * `typeName`, the name of the type to search for.
-* `libraries`, a list of two elements:
-	* A list of names of libraries to search in
-	* A boolean, whether language builtins should be searched or not.
+* `libraries`, a list of names of libraries to search in.
+* `include_builtins`, a boolean, whether language builtins should be searched or not.
 * `modules`, a list of names of modules to search in.
 * `page`: 0 for the first *n* results, 1 for the next *n*, etc.
 

--- a/backend/Cloogle.dcl
+++ b/backend/Cloogle.dcl
@@ -6,13 +6,14 @@ from Data.Maybe import :: Maybe
 from Text.JSON import generic JSONEncode, generic JSONDecode, :: JSONNode
 
 :: Request
-	= { unify     :: Maybe String
-	  , name      :: Maybe String
-	  , className :: Maybe String
-	  , typeName  :: Maybe String
-	  , modules   :: Maybe [String]
-	  , libraries :: Maybe ([String], Bool)
-	  , page      :: Maybe Int
+	= { unify            :: Maybe String
+	  , name             :: Maybe String
+	  , className        :: Maybe String
+	  , typeName         :: Maybe String
+	  , modules          :: Maybe [String]
+	  , libraries        :: Maybe [String]
+	  , include_builtins :: Maybe Bool
+	  , page             :: Maybe Int
 	  }
 
 :: Response

--- a/backend/Cloogle.dcl
+++ b/backend/Cloogle.dcl
@@ -13,6 +13,7 @@ from Text.JSON import generic JSONEncode, generic JSONDecode, :: JSONNode
 	  , modules          :: Maybe [String]
 	  , libraries        :: Maybe [String]
 	  , include_builtins :: Maybe Bool
+	  , include_core     :: Maybe Bool
 	  , page             :: Maybe Int
 	  }
 

--- a/backend/Cloogle.icl
+++ b/backend/Cloogle.icl
@@ -11,13 +11,14 @@ derive JSONDecode Request, Response, Result, ShortClassResult, BasicResult,
 
 instance zero Request
 where
-	zero = { unify     = Nothing
-	       , name      = Nothing
-	       , className = Nothing
-	       , typeName  = Nothing
-	       , modules   = Nothing
-	       , libraries = Nothing
-	       , page      = Nothing
+	zero = { unify            = Nothing
+	       , name             = Nothing
+	       , className        = Nothing
+	       , typeName         = Nothing
+	       , modules          = Nothing
+	       , libraries        = Nothing
+		   , include_builtins = Nothing
+	       , page             = Nothing
 	       }
 
 instance zero Response

--- a/backend/Cloogle.icl
+++ b/backend/Cloogle.icl
@@ -17,7 +17,8 @@ where
 	       , typeName         = Nothing
 	       , modules          = Nothing
 	       , libraries        = Nothing
-		   , include_builtins = Nothing
+	       , include_builtins = Nothing
+	       , include_core     = Nothing
 	       , page             = Nothing
 	       }
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,7 +6,6 @@ RUN mv /opt/clean/StdEnv/*.icl /opt/clean/lib/StdEnv
 RUN PACKAGES="subversion ca-certificates" \
 	&& apt-get update \
 	&& apt-get install -qq subversion ca-certificates \
-	&& svn checkout https://svn.cs.ru.nl/repos/SoccerFun/src /opt/clean/lib/SoccerFun \
 # Cleanup
 	&& ADDED_PACKAGES=`apt-mark showauto` \
 	&& apt-get remove --purge -qq $PACKAGES $ADDED_PACKAGES\
@@ -18,6 +17,8 @@ WORKDIR /usr/src/cloogle
 RUN PACKAGES="make subversion ca-certificates gcc" \
 	&& apt-get update \
 	&& apt-get install -qq $PACKAGES \
+	&& svn checkout https://svn.cs.ru.nl/repos/SoccerFun/src /opt/clean/lib/SoccerFun \
+	&& svn checkout https://svn.cs.ru.nl/repos/clean-libraries/trunk/Libraries/ObjectIO/ObjectIO /opt/clean/lib/ObjectIO \
 	&& make distclean \
 	&& make \
 # Cleanup

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -2,7 +2,7 @@ BIN:=CloogleServer builddb
 DB=types.json
 MAN:=builddb.1 # Others don't have --help/--version # $(addsuffix .1,$(BIN))
 CLM:=clm
-CLMFLAGS:=-dynamics -h 40M -nr -nt\
+CLMFLAGS:=-dynamics -h 80M -nr -nt\
 	-I $$CLEAN_HOME/lib/ArgEnv\
 	-I $$CLEAN_HOME/lib/Dynamics\
 	-I $$CLEAN_HOME/lib/Generics\

--- a/backend/TypeDB.dcl
+++ b/backend/TypeDB.dcl
@@ -31,20 +31,22 @@ from Type import ::Type, ::TypeVar, ::TVAssignment, ::TypeDef, class print(..),
 :: Location = Location Library Module LineNr LineNr Name
             | Builtin                               Name
 
+:: ModuleInfo = { is_core :: Bool }
+
 :: Name         :== String
 :: Library      :== String
 :: Module       :== String
 :: Class        :== String
 :: LineNr       :== Maybe Int
 
-derive gEq TypeDB
-
 instance zero TypeDB
 instance zero TypeExtras
+instance zero ModuleInfo
 
 instance print (Name, ExtendedType)
 
 getName :: Location -> Name
+isBuiltin :: Location -> Bool
 
 functionCount :: TypeDB -> Int
 macroCount :: TypeDB -> Int
@@ -99,6 +101,9 @@ getDerivations :: Name TypeDB -> [(Type, [Location])]
 putDerivation :: Name Type Location TypeDB -> TypeDB
 putDerivations :: Name [(Type, Location)] TypeDB -> TypeDB
 putDerivationss :: [(Name, [(Type, Location)])] TypeDB -> TypeDB
+
+getModule :: Library Module TypeDB -> Maybe ModuleInfo
+putModule :: Library Module ModuleInfo TypeDB -> TypeDB
 
 searchExact :: Type TypeDB -> [(Location, ExtendedType)]
 

--- a/backend/builddb.icl
+++ b/backend/builddb.icl
@@ -6,7 +6,7 @@ from TypeDB import ::TypeExtras{..}, ::Macro{..}, ::ModuleInfo{..},
 	instance zero TypeExtras, instance zero ModuleInfo
 
 // StdEnv
-from StdFunc import const, flip
+from StdFunc import const, flip, o
 import StdFile, StdList, StdMisc, StdArray, StdBool, StdString, StdTuple
 
 // CleanPlatform
@@ -81,6 +81,7 @@ instance zero CLI where
 	                   , ("iTasks-SDK/Dependencies/clean-sapl/src", const False)
 	                   , ("iTasks-SDK/Server", startsWith "iTasks._Framework")
 	                   , ("iTasks-SDK/Tests", const False)
+	                   , ("ObjectIO", not o startsWith "Std")
 	                   , ("SoccerFun/Game", const False)
 	                   , ("SoccerFun/Gui", const False)
 	                   , ("SoccerFun/StdLibExt", const False)

--- a/backend/builddb.icl
+++ b/backend/builddb.icl
@@ -2,15 +2,18 @@ module builddb
 
 // Project libraries
 import qualified TypeDB as DB
-from TypeDB import ::TypeExtras{..}, instance zero TypeExtras, ::Macro{..}
+from TypeDB import ::TypeExtras{..}, ::Macro{..}, ::ModuleInfo{..},
+	instance zero TypeExtras, instance zero ModuleInfo
 
 // StdEnv
+from StdFunc import const, flip
 import StdFile, StdList, StdMisc, StdArray, StdBool, StdString, StdTuple
 
 // CleanPlatform
 import Data.Maybe, Data.Either, Data.Error, Data.Func, Data.Tuple, Data.Functor
 import Control.Applicative, Control.Monad
-from Text import class Text(concat,replaceSubString,indexOf), instance Text String
+from Text import class Text(concat,replaceSubString,indexOf,startsWith),
+	instance Text String
 import System.Directory, System.CommandLine
 
 // CleanTypeUnifier
@@ -48,7 +51,7 @@ from parse import wantModule
 :: CLI = { help    :: Bool
          , version :: Bool
          , root    :: String
-         , libs    :: [String]
+         , libs    :: [(String, String -> Bool)]
          , exclude :: [String]
          }
 
@@ -56,33 +59,33 @@ instance zero CLI where
 	zero = { version = False
 	       , help    = False
 	       , root    = "/opt/clean/lib/"
-	       , libs    = [ "StdEnv"
-	                   , "StdLib"
-	                   , "ArgEnv"
-	                   , "Directory"
-	                   , "Dynamics"
-	                   , "Gast"
-	                   , "Generics"
-	                   , "MersenneTwister"
-	                   , "TCPIP"
-	                   , "clean-platform/OS-Independent"
-	                   , "clean-platform/OS-Linux"
-	                   , "clean-platform/OS-Linux-32"
-	                   , "clean-platform/OS-Linux-64"
-	                   , "clean-platform/OS-Mac"
-	                   , "clean-platform/OS-Posix"
-	                   , "clean-platform/OS-Windows"
-	                   , "clean-platform/OS-Windows-32"
-	                   , "clean-platform/OS-Windows-64"
-	                   , "iTasks-SDK/Dependencies/graph_copy"
-	                   , "iTasks-SDK/Dependencies/clean-sapl/src"
-	                   , "iTasks-SDK/Server"
-	                   , "iTasks-SDK/Tests"
-	                   , "SoccerFun/Game"
-	                   , "SoccerFun/Gui"
-	                   , "SoccerFun/StdLibExt"
-	                   , "SoccerFun/StdReferee"
-	                   , "SoccerFun/StdTeam"
+	       , libs    = [ ("StdEnv", const False)
+	                   , ("StdLib", const False)
+	                   , ("ArgEnv", const False)
+	                   , ("Directory", const False)
+	                   , ("Dynamics", const False)
+	                   , ("Gast", const False)
+	                   , ("Generics", const False)
+	                   , ("MersenneTwister", const False)
+	                   , ("TCPIP", const False)
+	                   , ("clean-platform/OS-Independent", const False)
+	                   , ("clean-platform/OS-Linux", const False)
+	                   , ("clean-platform/OS-Linux-32", const False)
+	                   , ("clean-platform/OS-Linux-64", const False)
+	                   , ("clean-platform/OS-Mac", const False)
+	                   , ("clean-platform/OS-Posix", const False)
+	                   , ("clean-platform/OS-Windows", const False)
+	                   , ("clean-platform/OS-Windows-32", const False)
+	                   , ("clean-platform/OS-Windows-64", const False)
+	                   , ("iTasks-SDK/Dependencies/graph_copy", const False)
+	                   , ("iTasks-SDK/Dependencies/clean-sapl/src", const False)
+	                   , ("iTasks-SDK/Server", startsWith "iTasks._Framework")
+	                   , ("iTasks-SDK/Tests", const False)
+	                   , ("SoccerFun/Game", const False)
+	                   , ("SoccerFun/Gui", const False)
+	                   , ("SoccerFun/StdLibExt", const False)
+	                   , ("SoccerFun/StdReferee", const False)
+	                   , ("SoccerFun/StdTeam", const False)
 	                   ]
 	       , exclude = [ "StdEnv/_startup"
 	                   , "StdEnv/_system"
@@ -110,7 +113,7 @@ Start w
 	(Right cli)
 	| cli.help    = fclose (f <<< USAGE) w
 	| cli.version = fclose (f <<< VERSION) w
-	# (modss, w)  = mapSt (\l -> findModules cli.exclude cli.root l "") cli.libs w
+	# (modss, w)  = mapSt (flip (uncurry $ findModules cli.exclude cli.root) "") cli.libs w
 	# mods        = flatten modss
 	# (st, w)     = init_identifiers newHeap w
 	# cache       = empty_cache st
@@ -127,10 +130,11 @@ Start w
 | not ok = abort "Couldn't close stdio"
 = w
 where
-	loop :: String [(String,String)] 'DB'.TypeDB *DclCache *World -> *('DB'.TypeDB, *World)
+	loop :: String [(String,String,Bool)] 'DB'.TypeDB
+		*DclCache *World -> *('DB'.TypeDB, *World)
 	loop _ [] db _ w = (db,w)
-	loop root [(lib,mod):list] db cache w
-	# (db, cache, w) = getModuleTypes root mod lib cache db w
+	loop root [(lib,mod,iscore):list] db cache w
+	# (db, cache, w) = getModuleTypes root mod lib iscore cache db w
 	# w = snd (fclose (stderr <<< lib <<< ": " <<< mod <<< "\n") w)
 	= loop root list db cache w
 
@@ -142,7 +146,7 @@ where
 		("-l", []) = Left "'-l' requires an argument"
 		("-r", []) = Left "'-r' requires an argument"
 		("-r", [x:xs]) = (\c->{c & root=x}) <$> parseCLI xs
-		("-l", [x:xs]) = (\c->{c & libs=[x:c.libs]}) <$> parseCLI xs
+		("-l", [x:xs]) = (\c->{c & libs=[(x,const False):c.libs]}) <$> parseCLI xs
 		(x, _) = Left $ "Unknown option '" +++ x +++ "'"
 
 	printStats :: !'DB'.TypeDB !*File -> *File
@@ -207,15 +211,17 @@ where
 	deft = {'Type'.td_name="", 'Type'.td_uniq=False, 'Type'.td_args=[], 'Type'.td_rhs='T'.TDRAbstract}
 	defc = {'Type'.cons_name="", 'Type'.cons_args=[], 'Type'.cons_exi_vars=[], 'Type'.cons_context=[], 'Type'.cons_priority=Nothing}
 
-//             Exclude   Root    Library Base module            Library Module
-findModules :: ![String] !String !String !String !*World -> *(![(String,String)], !*World)
-findModules ex root lib base w
+//             Exclude   Root    Library        Check for core       Base module
+findModules :: ![String] !String !'DB'.Library ('DB'.Module -> Bool) !String !*World
+	-> *(![('DB'.Library, 'DB'.Module, Bool)], !*World)
+findModules ex root lib iscore base w
 | any (\e -> indexOf e path <> -1) ex = ([], w)
 #! (fps, w)   = readDirectory path w
 | isError fps = ([], w)
 #! fps        = fromOk fps
-#! mods       = map (\s -> (lib, basedot +++ s % (0, size s - 5))) $ filter included $ filter isDclModule fps
-#! (moremodss,w) = mapSt (\d -> findModules ex root lib (basedot +++ d)) (filter isDirectory fps) w
+#! mods       = map (\s -> let mod = basedot +++ s % (0, size s - 5) in
+	(lib, mod, iscore mod)) $ filter included $ filter isDclModule fps
+#! (moremodss,w) = mapSt (\d -> findModules ex root lib iscore (basedot +++ d)) (filter isDirectory fps) w
 = (removeDup (mods ++ flatten moremodss), w)
 where
 	path = root +++ "/" +++ lib +++ if (base == "") "" "/" +++ replaceSubString "." "/" base
@@ -230,8 +236,9 @@ where
 	isDirectory :: String -> Bool
 	isDirectory s = not $ isMember '.' $ fromString s
 
-getModuleTypes :: String String String *DclCache 'DB'.TypeDB *World -> *('DB'.TypeDB, *DclCache, *World)
-getModuleTypes root mod lib cache db w
+getModuleTypes :: String 'DB'.Module 'DB'.Library Bool
+	*DclCache 'DB'.TypeDB *World -> *('DB'.TypeDB, *DclCache, *World)
+getModuleTypes root mod lib iscore cache db w
 # (Right dcl,cache,w) = readModule False cache w
 # (icl,cache,w) = readModule True cache w
 # icl = case icl of (Left _) = Nothing; (Right x) = Just x
@@ -247,6 +254,7 @@ getModuleTypes root mod lib cache db w
 # db  = 'DB'.putFunctions (pd_generics lib mod dcl.mod_defs) db
 # db  = 'DB'.putDerivationss (pd_derivations lib mod dcl.mod_defs) db
 # db  = 'DB'.putMacros (pd_macros lib mod dcl.mod_defs) db
+# db  = 'DB'.putModule lib mod {zero & is_core=iscore} db
 = (db,cache,w)
 where
 	mkdir :: String -> String

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -16,7 +16,8 @@ RUN mkdir -p /opt/clean && cd /opt/clean &&\
 	make -j &&\
 	mv StdEnv/*.icl lib/StdEnv
 
-RUN svn checkout https://svn.cs.ru.nl/repos/SoccerFun/src /opt/clean/lib/SoccerFun
+RUN svn checkout https://svn.cs.ru.nl/repos/SoccerFun/src /opt/clean/lib/SoccerFun &&\
+	svn checkout https://svn.cs.ru.nl/repos/clean-libraries/trunk/Libraries/ObjectIO/ObjectIO /opt/clean/lib/ObjectIO
 
 # Pygments, for highlighting
 RUN apt-get update && apt-get install -y python3.4 python3-pip mercurial

--- a/frontend/api.php
+++ b/frontend/api.php
@@ -92,13 +92,15 @@ if($_SERVER['REQUEST_METHOD'] !== 'GET'){
 	}
 
 	if (isset($_GET['lib'])) {
-		$command['libraries'] = [explode(',', $_GET['lib']), false];
+		$command['libraries'] = explode(',', $_GET['lib']);
 	}
 
-	if (isset($_GET['libs_builtin'])) {
-		if (!isset($command['libraries'][0]))
-			$command['libraries'][0] = [];
-		$command['libraries'][1] = $_GET['libs_builtin'] == 'true';
+	if (isset($_GET['include_builtins'])) {
+		$command['include_builtins'] = $_GET['include_builtins'] == 'true';
+	}
+
+	if (isset($_GET['include_core'])) {
+		$command['include_core'] = $_GET['include_core'] == 'true';
 	}
 
 	if (isset($_GET['mod'])) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -74,6 +74,8 @@
 		&nbsp;
 		<label><input type="checkbox" id="search_advanced"/> advanced</label>
 		<div id="advanced" style="display:none;">
+			<label><input type="checkbox" id="include_builtins" checked="checked"/> Include language builtins</label><br/>
+			<label><input type="checkbox" id="include_core"/> Include library cores</label><br/>
 			<table id="lib_selection">
 				<tr>
 					<th><a title="Toggle selection" href="javascript:toggleLibSelection('libs-clean-2.4')">Clean 2.4</a></th>
@@ -83,7 +85,6 @@
 				</tr>
 				<tr>
 					<td id="libs-clean-2.4">
-						<label><input type="checkbox" class="search_libs" checked="checked" value="__builtin"/> Language builtins</label><br/>
 						<label><input type="checkbox" class="search_libs" checked="checked" value="StdEnv"/> StdEnv</label><br/>
 						<label><input type="checkbox" class="search_libs" checked="checked" value="StdLib"/> StdLib</label><br/>
 						<label><input type="checkbox" class="search_libs" checked="checked" value="ArgEnv"/> ArgEnv</label><br/>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -93,7 +93,8 @@
 						<label><input type="checkbox" class="search_libs" checked="checked" value="Gast"/> Gast</label><br/>
 						<label><input type="checkbox" class="search_libs" checked="checked" value="Generics"/> Generics</label><br/>
 						<label><input type="checkbox" class="search_libs" checked="checked" value="MersenneTwister"/> MersenneTwister</label><br/>
-						<label><input type="checkbox" class="search_libs" checked="checked" value="TCPIP"/> TCPIP</label><br/>
+						<label><input type="checkbox" class="search_libs" checked="checked" value="ObjectIO">ObjectIO</label><br/>
+						<label><input type="checkbox" class="search_libs" checked="checked" value="TCPIP"/> TCPIP</label>
 					</td>
 					<td id="libs-clean-platform">
 						<label><input type="checkbox" class="search_libs" checked="checked" value="clean-platform/OS-Independent"/> clean-platform/OS-Independent</label><br/>
@@ -104,13 +105,13 @@
 						<label><input type="checkbox" class="search_libs" checked="checked" value="clean-platform/OS-Posix"/> clean-platform/OS-Posix</label><br/>
 						<label><input type="checkbox" class="search_libs" checked="checked" value="clean-platform/OS-Windows"/> clean-platform/OS-Windows</label><br/>
 						<label><input type="checkbox" class="search_libs" checked="checked" value="clean-platform/OS-Windows-32"/> clean-platform/OS-Windows-32</label><br/>
-						<label><input type="checkbox" class="search_libs" checked="checked" value="clean-platform/OS-Windows-64"/> clean-platform/OS-Windows-64</label><br/>
+						<label><input type="checkbox" class="search_libs" checked="checked" value="clean-platform/OS-Windows-64"/> clean-platform/OS-Windows-64</label>
 					</td>
 					<td id="libs-itasks">
 						<label><input type="checkbox" class="search_libs" checked="checked" value="iTasks-SDK/Dependencies/graph_copy"/> iTasks-SDK/Dependencies/graph_copy</label><br/>
 						<label><input type="checkbox" class="search_libs" checked="checked" value="iTasks-SDK/Dependencies/clean-sapl/src"/> iTasks-SDK/Dependencies/clean-sapl/src</label><br/>
 						<label><input type="checkbox" class="search_libs" checked="checked" value="iTasks-SDK/Server"/> iTasks-SDK/Server</label><br/>
-						<label><input type="checkbox" class="search_libs" checked="checked" value="iTasks-SDK/Tests"/> iTasks-SDK/Tests</label><br/>
+						<label><input type="checkbox" class="search_libs" checked="checked" value="iTasks-SDK/Tests"/> iTasks-SDK/Tests</label>
 					</td>
 					<td id="libs-misc">
 						<label><input type="checkbox" class="search_libs" value="SoccerFun">SoccerFun</label>


### PR DESCRIPTION
See #71.

- This is not backwards compatible with old methods for filtering libraries.
- Adding ObjectIO to the database significantly. increases RAM usage.