### PR TITLE
WIP: Make the pygments formatter output clickable

### DIFF
--- a/frontend/src/cloogle_pygments.py
+++ b/frontend/src/cloogle_pygments.py
@@ -3,7 +3,7 @@ import sys
 import pygments
 import pygments.lexers
 import pygments.formatters
-from pygments.token import Token
+from pygments.token import Literal, Name, Operator
 
 _escape_html_table = {
     ord('&'): u'&amp;',
@@ -12,6 +12,9 @@ _escape_html_table = {
     ord('"'): u'&quot;',
     ord("'"): u'&#39;',
 }
+
+CLEAN_SYNTAX_TOKENS = ['=', '=:', ':==', '|', '->', '(', ')', ':', '::', '::!',
+        '..', '_', '\\', '.', '#', '#!', '!', '\\\\', '<-', '<-:', '<-|']
 
 
 # This is blatantly stolen from the HTML formatter
@@ -44,16 +47,15 @@ class CloogleHtmlFormatter(pygments.formatters.HtmlFormatter):
                 cspan = cls and '<span class="%s">' % cls or ''
 
             safe_value = value.translate(escape_table)
-            if ttype in [Token.Name.Class, Token.Name, Token.Operator] \
-                    and value not in ['=', '|', '->', '(', ')', ':', '::',
-                                      '..', '_', '\\']:
+            if ttype in [Name.Class, Name, Operator, Literal] \
+                    and value not in CLEAN_SYNTAX_TOKENS:
                 value = u'<a href="https://cloogle.org/#%s">%s</a>' % (
                     urllib.parse.quote(value), safe_value)
             else:
                 value = safe_value
             parts = value.split('\n')
 
-            if tagsfile and ttype in Token.Name:
+            if tagsfile and ttype in Name:
                 filename, linenumber = self._lookup_ctag(value)
                 if linenumber:
                     base, filename = os.path.split(filename)

--- a/frontend/src/cloogle_pygments.py
+++ b/frontend/src/cloogle_pygments.py
@@ -48,7 +48,7 @@ class CloogleHtmlFormatter(pygments.formatters.HtmlFormatter):
                     and value not in ['=', '|', '->', '(', ')', ':', '::',
                                       '..', '_', '\\']:
                 value = u'<a href="https://cloogle.org/#%s">%s</a>' % (
-                    urllib.quote(value), safe_value)
+                    urllib.parse.quote(value), safe_value)
             else:
                 value = safe_value
             parts = value.split('\n')
@@ -98,7 +98,7 @@ class CloogleHtmlFormatter(pygments.formatters.HtmlFormatter):
             yield 1, ''.join(line)
 
 
-print pygments.highlight(
+print(pygments.highlight(
     ''.join(sys.stdin),
     pygments.lexers.get_lexer_by_name('clean'),
     CloogleHtmlFormatter(
@@ -106,7 +106,7 @@ print pygments.highlight(
         linenos=True,
         linespans='line',
         encoding='iso8859',
-        hl_lines=[] if len(sys.argv) == 0 else map(int, sys.argv[1:]),
+        hl_lines=[] if len(sys.argv) == 0 else [int(a) for a in sys.argv[1:]],
         cssfile='view.css',
         noclobber_cssfile=True,
-        ))
+        )).decode('utf-8'))

--- a/frontend/src/cloogle_pygments.py
+++ b/frontend/src/cloogle_pygments.py
@@ -1,0 +1,112 @@
+import urllib
+import sys
+import pygments
+import pygments.lexers
+import pygments.formatters
+from pygments.token import Token
+
+_escape_html_table = {
+    ord('&'): u'&amp;',
+    ord('<'): u'&lt;',
+    ord('>'): u'&gt;',
+    ord('"'): u'&quot;',
+    ord("'"): u'&#39;',
+}
+
+
+# This is blatantly stolen from the HTML formatter
+# Original code has a BSD licence
+class CloogleHtmlFormatter(pygments.formatters.HtmlFormatter):
+    def _format_lines(self, tokensource):
+        """
+        Just format the tokens, without any wrapping tags.
+        Yield individual lines.
+        """
+        nocls = self.noclasses
+        lsep = self.lineseparator
+        # for <span style=""> lookup only
+        getcls = self.ttype2class.get
+        c2s = self.class2style
+        escape_table = _escape_html_table
+        tagsfile = self.tagsfile
+
+        lspan = ''
+        line = []
+        for ttype, value in tokensource:
+            if nocls:
+                cclass = getcls(ttype)
+                while cclass is None:
+                    ttype = ttype.parent
+                    cclass = getcls(ttype)
+                cspan = cclass and '<span style="%s">' % c2s[cclass][0] or ''
+            else:
+                cls = self._get_css_classes(ttype)
+                cspan = cls and '<span class="%s">' % cls or ''
+
+            safe_value = value.translate(escape_table)
+            if ttype in [Token.Name.Class, Token.Name, Token.Operator] \
+                    and value not in ['=', '|', '->', '(', ')', ':', '::',
+                                      '..', '_', '\\']:
+                value = u'<a href="https://cloogle.org/#%s">%s</a>' % (
+                    urllib.quote(value), safe_value)
+            else:
+                value = safe_value
+            parts = value.split('\n')
+
+            if tagsfile and ttype in Token.Name:
+                filename, linenumber = self._lookup_ctag(value)
+                if linenumber:
+                    base, filename = os.path.split(filename)
+                    if base:
+                        base += '/'
+                    filename, extension = os.path.splitext(filename)
+                    url = self.tagurlformat % {'path': base, 'fname': filename,
+                                               'fext': extension}
+                    parts[0] = "<a href=\"%s#%s-%d\">%s" % \
+                        (url, self.lineanchors, linenumber, parts[0])
+                    parts[-1] = parts[-1] + "</a>"
+
+            # for all but the last line
+            for part in parts[:-1]:
+                if line:
+                    if lspan != cspan:
+                        line.extend(((lspan and '</span>'), cspan, part,
+                                     (cspan and '</span>'), lsep))
+                    else:  # both are the same
+                        line.extend((part, (lspan and '</span>'), lsep))
+                    yield 1, ''.join(line)
+                    line = []
+                elif part:
+                    yield 1, ''.join(
+                        (cspan, part, (cspan and '</span></a>'), lsep))
+                else:
+                    yield 1, lsep
+            # for the last line
+            if line and parts[-1]:
+                if lspan != cspan:
+                    line.extend(((lspan and '</span>'), cspan, parts[-1]))
+                    lspan = cspan
+                else:
+                    line.append(parts[-1])
+            elif parts[-1]:
+                line = [cspan, parts[-1]]
+                lspan = cspan
+            # else we neither have to open a new span nor set lspan
+
+        if line:
+            line.extend(((lspan and '</span>'), lsep))
+            yield 1, ''.join(line)
+
+
+print pygments.highlight(
+    ''.join(sys.stdin),
+    pygments.lexers.get_lexer_by_name('clean'),
+    CloogleHtmlFormatter(
+        full=True,
+        linenos=True,
+        linespans='line',
+        encoding='iso8859',
+        hl_lines=[] if len(sys.argv) == 0 else map(int, sys.argv[1:]),
+        cssfile='view.css',
+        noclobber_cssfile=True,
+        ))

--- a/frontend/src/view.css
+++ b/frontend/src/view.css
@@ -1,4 +1,5 @@
 a { color: inherit; text-decoration: inherit; }
+h2 { display: none; }
 td.linenos { background-color: #f0f0f0; padding-right: 10px; }
 span.lineno { background-color: #f0f0f0; padding: 0 5px 0 5px; }
 pre { line-height: 125%; }

--- a/frontend/src/view.css
+++ b/frontend/src/view.css
@@ -1,0 +1,73 @@
+a { color: inherit; text-decoration: inherit; }
+td.linenos { background-color: #f0f0f0; padding-right: 10px; }
+span.lineno { background-color: #f0f0f0; padding: 0 5px 0 5px; }
+pre { line-height: 125%; }
+body .hll { background-color: #fc8 }
+body  { background: #f8f8f8; }
+body .c { color: #408080; font-style: italic } /* Comment */
+body .err { border: 1px solid #FF0000 } /* Error */
+body .k { color: #008000; font-weight: bold } /* Keyword */
+body .o { color: #666666 } /* Operator */
+body .ch { color: #408080; font-style: italic } /* Comment.Hashbang */
+body .cm { color: #408080; font-style: italic } /* Comment.Multiline */
+body .cp { color: #BC7A00 } /* Comment.Preproc */
+body .cpf { color: #408080; font-style: italic } /* Comment.PreprocFile */
+body .c1 { color: #408080; font-style: italic } /* Comment.Single */
+body .cs { color: #408080; font-style: italic } /* Comment.Special */
+body .gd { color: #A00000 } /* Generic.Deleted */
+body .ge { font-style: italic } /* Generic.Emph */
+body .gr { color: #FF0000 } /* Generic.Error */
+body .gh { color: #000080; font-weight: bold } /* Generic.Heading */
+body .gi { color: #00A000 } /* Generic.Inserted */
+body .go { color: #888888 } /* Generic.Output */
+body .gp { color: #000080; font-weight: bold } /* Generic.Prompt */
+body .gs { font-weight: bold } /* Generic.Strong */
+body .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+body .gt { color: #0044DD } /* Generic.Traceback */
+body .kc { color: #008000; font-weight: bold } /* Keyword.Constant */
+body .kd { color: #008000; font-weight: bold } /* Keyword.Declaration */
+body .kn { color: #008000; font-weight: bold } /* Keyword.Namespace */
+body .kp { color: #008000 } /* Keyword.Pseudo */
+body .kr { color: #008000; font-weight: bold } /* Keyword.Reserved */
+body .kt { color: #B00040 } /* Keyword.Type */
+body .m { color: #666666 } /* Literal.Number */
+body .s { color: #BA2121 } /* Literal.String */
+body .na { color: #7D9029 } /* Name.Attribute */
+body .nb { color: #008000 } /* Name.Builtin */
+body .nc { color: #0000FF; font-weight: bold } /* Name.Class */
+body .no { color: #880000 } /* Name.Constant */
+body .nd { color: #AA22FF } /* Name.Decorator */
+body .ni { color: #999999; font-weight: bold } /* Name.Entity */
+body .ne { color: #D2413A; font-weight: bold } /* Name.Exception */
+body .nf { color: #0000FF } /* Name.Function */
+body .nl { color: #A0A000 } /* Name.Label */
+body .nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
+body .nt { color: #008000; font-weight: bold } /* Name.Tag */
+body .nv { color: #19177C } /* Name.Variable */
+body .ow { color: #AA22FF; font-weight: bold } /* Operator.Word */
+body .w { color: #bbbbbb } /* Text.Whitespace */
+body .mb { color: #666666 } /* Literal.Number.Bin */
+body .mf { color: #666666 } /* Literal.Number.Float */
+body .mh { color: #666666 } /* Literal.Number.Hex */
+body .mi { color: #666666 } /* Literal.Number.Integer */
+body .mo { color: #666666 } /* Literal.Number.Oct */
+body .sa { color: #BA2121 } /* Literal.String.Affix */
+body .sb { color: #BA2121 } /* Literal.String.Backtick */
+body .sc { color: #BA2121 } /* Literal.String.Char */
+body .dl { color: #BA2121 } /* Literal.String.Delimiter */
+body .sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
+body .s2 { color: #BA2121 } /* Literal.String.Double */
+body .se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
+body .sh { color: #BA2121 } /* Literal.String.Heredoc */
+body .si { color: #BB6688; font-weight: bold } /* Literal.String.Interpol */
+body .sx { color: #008000 } /* Literal.String.Other */
+body .sr { color: #BB6688 } /* Literal.String.Regex */
+body .s1 { color: #BA2121 } /* Literal.String.Single */
+body .ss { color: #19177C } /* Literal.String.Symbol */
+body .bp { color: #008000 } /* Name.Builtin.Pseudo */
+body .fm { color: #0000FF } /* Name.Function.Magic */
+body .vc { color: #19177C } /* Name.Variable.Class */
+body .vg { color: #19177C } /* Name.Variable.Global */
+body .vi { color: #19177C } /* Name.Variable.Instance */
+body .vm { color: #19177C } /* Name.Variable.Magic */
+body .il { color: #666666 } /* Literal.Number.Integer.Long */

--- a/frontend/src/view.php
+++ b/frontend/src/view.php
@@ -19,8 +19,7 @@ $fname = CLEANHOME . '/lib/' . $lib . '/' . $mod . '.' . $iclordcl;
 $efname = escapeshellarg($fname);
 
 if ($highlight) {
-	# Output is printed to stdout
-	exec("python2 cloogle_pygments.py $hl_lines < $efname");
+	system("python3 cloogle_pygments.py $hl_lines < $efname");
 } else {
 	header('Content-Type: text/plain');
 	echo file_get_contents($fname);

--- a/frontend/src/view.php
+++ b/frontend/src/view.php
@@ -9,7 +9,7 @@ if (!isset($_REQUEST['lib']) || !isset($_REQUEST['mod'])) {
 
 $iclordcl = isset($_REQUEST['icl']) ? 'icl' : 'dcl';
 $highlight = isset($_REQUEST['hl']) ? true : false;
-$hl_lines = isset($_REQUEST['line']) ? 'hl_lines=' . $_REQUEST['line'] : '';
+$hl_lines = isset($_REQUEST['line']) ? escapeshellarg($_REQUEST['line']) : '';
 
 $lib = preg_replace('/[^\\w\\/\\-]/', '', $_REQUEST['lib']);
 $mod = str_replace('.', '/', $_REQUEST['mod']);
@@ -19,18 +19,8 @@ $fname = CLEANHOME . '/lib/' . $lib . '/' . $mod . '.' . $iclordcl;
 $efname = escapeshellarg($fname);
 
 if ($highlight) {
-	$out = [];
-	$code = -1;
-	$cmd = 'pygmentize -v -l clean -f html -O full,linenos,linespans=line,' . $hl_lines . ',encoding=iso8859';
-	exec("$cmd $efname", $out, $code);
-	$out = array_filter($out, function($str) { return $str != '<h2></h2>'; });
-	$out = array_map(function ($str) {
-		return str_replace(
-			'</style>',
-			'.hll { background-color: #fc8 !important; }</style>',
-			$str);
-	}, $out);
-	echo implode("\n", $out);
+	# Output is printed to stdout
+	exec("python2 cloogle_pygments.py $hl_lines < $efname");
 } else {
 	header('Content-Type: text/plain');
 	echo file_get_contents($fname);


### PR DESCRIPTION
This still needs to be tested but should work.

The following things are added:
- Externalize the CSS, this includes the darkened highlights and makes
  such changes easier.
- Adapt `view.php` to run the custom python script
- Extend the HTML pygments formatter to include cloogle links and wrap
  this in a python script. The python scripts transforms stdin to stdout
  and highlights the line numbers given as an argument.

The following thing needs to be done:
- The first `<h2>` tag should be removed again. Preferably in the python script and not in the php code.

