### PR TITLE
Clean frontend

### DIFF
--- a/frontend/api.js
+++ b/frontend/api.js
@@ -177,21 +177,22 @@ function getResults(str, libs, include_builtins, include_core, page) {
 			'&mod=' + encodeURIComponent(basic['modul']) +
 			'&hl';
 		var iclUrl = dclUrl + '&icl';
+		var dclLine = '';
+		var iclLine = '';
 		if ('dcl_line' in basic) {
 			dclUrl += '&line=' + basic['dcl_line'] + '#line-' + basic['dcl_line'];
+			dclLine = ':' + basic['dcl_line'];
 		}
 		if ('icl_line' in basic) {
 			iclUrl += '&line=' + basic['icl_line'] + '#line-' + basic['icl_line'];
+			iclLine = ':' + basic['icl_line'];
 		}
 
 		var basicData = [
-			['Library',  basic['library']],
-			['Filename', '<a href="' + dclUrl + '" target="_blank">' +
-				basic['filename'] + ('dcl_line' in basic ? ':' + basic['dcl_line'] : '') +
-				'</a> (<a href="' + iclUrl + '" target="_blank">icl' +
-				('icl_line' in basic ? ':' + basic['icl_line'] : '') + '</a>)'],
-			['Module',   basic['modul']],
-			['Distance', basic['distance']]
+			[basic['library'] + ': ' +
+				basic['modul'] + ' (' +
+				'<a href="' + dclUrl + '" target="_blank">dcl' + dclLine + '</a>; ' +
+				'<a href="' + iclUrl + '" target="_blank">icl' + iclLine + '</a>)']
 		];
 
 		if ('builtin' in basic && basic['builtin']) {
@@ -264,10 +265,11 @@ function getResults(str, libs, include_builtins, include_core, page) {
 								highlightFunction, 'generic')]);
 				}
 				return '<hr/>' +
-					makeTable(basicData.concat(specificData)) +
+					makeTable(basicData) +
 					'<pre>' +
 					highlightTypeDef(specific['type'], highlightCallback) +
-					'</pre>';
+					'</pre>' +
+					makeTable(specificData);
 				break;
 			case 'ClassResult':
 				var instancesId = 'instances-' + (instancesIdCounter++);
@@ -277,7 +279,7 @@ function getResults(str, libs, include_builtins, include_core, page) {
 						highlightType);
 				var specificData = [['Instances', instances]];
 				var html = '<hr/>' +
-					makeTable(basicData.concat(specificData)) + '<pre>' +
+					makeTable(basicData) + '<pre>' +
 					highlightClassDef(
 							'class ' + specific['class_heading'] +
 							(specific['class_funs'].length > 0 ? ' where' : ''),
@@ -288,6 +290,7 @@ function getResults(str, libs, include_builtins, include_core, page) {
 							highlightCallback, 'macro');
 				}
 				html += '</pre>';
+				html += makeTable(specificData);
 				return html;
 				break;
 			case 'MacroResult':
@@ -303,8 +306,9 @@ function getResults(str, libs, include_builtins, include_core, page) {
 					specificData.push(['<span class="core-module">' +
 							'This is a core module and should usually only be used internally.' +
 							'</span>']);
-				return '<hr/>' + makeTable(basicData.concat(specificData)) +
-					'<pre>' + highlightFunction('import ' + basic['modul']) + '</pre>';
+				return '<hr/>' + makeTable(basicData) +
+					'<pre>' + highlightFunction('import ' + basic['modul']) + '</pre>' +
+					makeTable(specificData);
 				break;
 			default:
 				return '';

--- a/frontend/api.js
+++ b/frontend/api.js
@@ -12,9 +12,12 @@ var old_libs = null;
 var old_include_builtins = null;
 var old_include_core = null;
 
-function toggle(name) {
-	var e = document.getElementById(name);
+function toggleElement(e) {
 	e.style.display = e.style.display == 'block' ? 'none' : 'block';
+}
+
+function toggle(name) {
+	toggleElement(document.getElementById(name));
 }
 
 function toggleLibSelection(className) {
@@ -55,8 +58,6 @@ function highlightCallback(span, cls, str) {
 	}
 }
 
-var instancesIdCounter = 0;
-var derivationsIdCounter = 0;
 function getResults(str, libs, include_builtins, include_core, page) {
 	if (str == null)  str  = old_str;
 	if (libs == null) libs = old_libs;
@@ -101,30 +102,32 @@ function getResults(str, libs, include_builtins, include_core, page) {
 		return html;
 	}
 
-	var makeInstanceTable = function (id, list, highlightf, highlightstart) {
+	var makeInstanceTable = function (list, highlightf, highlightstart) {
 		if (list.length == 0)
 			return '0';
 
-		var instances = '<a href="javascript:toggle(\'' + id + '\')">show / hide</a>';
-		instances += '<table id="' + id + '" style="display:none;">';
+		var instances = '<table>';
+
 		var makeInstanceUrl = function (loc) {
 			var dclUrl =
 				'src/view.php?lib=' + encodeURIComponent(loc[0]) +
 				'&mod=' + encodeURIComponent(loc[1]) +
 				'&hl';
 			var iclUrl = dclUrl + '&icl';
+
 			if (loc[2].length > 1)
 				dclUrl += '&line=' + loc[2][1] + '#line-' + loc[2][1];
 			if (loc[3].length > 1)
 				iclUrl += '&line=' + loc[3][1] + '#line-' + loc[3][1];
-			return '<a target="_blank" ' +
-				'href="' + dclUrl + '" ' +
-				'title="' + loc[0] + '">' + loc[1] +
-				(loc[2].length > 1 ? ':' + loc[2][1] : '') +
-				'</a> (<a target="_blank" href="' + iclUrl + '">icl' +
-				(loc[3].length > 1 ? ':' + loc[3][1] : '') +
-				'</a>)';
+
+			return loc[1] +
+				' (<a target="_blank" href="' + dclUrl + '">dcl' +
+					(loc[2].length > 1 ? ':' + loc[2][1] : '') + '</a>; ' +
+				'<a target="_blank" href="' + iclUrl + '">icl' +
+					(loc[3].length > 1 ? ':' + loc[3][1] : '') + '</a>) ' +
+				'(' + loc[0] + ')';
 		}
+
 		for (var i in list) {
 			instances += '<tr><th>';
 			if (typeof list[i][0] === 'object') {
@@ -161,17 +164,15 @@ function getResults(str, libs, include_builtins, include_core, page) {
 				}
 				locs += makeInstanceUrl(loc);
 			}
-			instances += '<td>in: ' + locs + '</td></tr>';
+
+			instances += '<td>&nbsp;in ' + locs + '</td></tr>';
 		}
 		instances += '</table>';
+
 		return instances;
 	}
 
-	var makeResultHTML = function (result) {
-		var kind = result[0];
-		var basic = result[1][0];
-		var specific = result[1][1];
-
+	var makeGenericResultHTML = function (basic, extraData, code) {
 		var dclUrl =
 			'src/view.php?lib=' + encodeURIComponent(basic['library']) +
 			'&mod=' + encodeURIComponent(basic['modul']) +
@@ -188,128 +189,122 @@ function getResults(str, libs, include_builtins, include_core, page) {
 			iclLine = ':' + basic['icl_line'];
 		}
 
-		var basicData = [
-			[basic['library'] + ': ' +
+		var basicText = basic['library'] + ': ' +
 				basic['modul'] + ' (' +
 				'<a href="' + dclUrl + '" target="_blank">dcl' + dclLine + '</a>; ' +
-				'<a href="' + iclUrl + '" target="_blank">icl' + iclLine + '</a>)']
-		];
+				'<a href="' + iclUrl + '" target="_blank">icl' + iclLine + '</a>)';
 
-		if ('builtin' in basic && basic['builtin']) {
-			basicData.splice(0,3);
-			basicData.push(['Builtin', 'yes (actual implementation may differ)']);
+		if ('builtin' in basic && basic['builtin'])
+			basicText = [['Clean core (actual implementation may differ)']];
+
+		if (extraData.length > 0) {
+			basicText = '<span class="more" title="More details" ' +
+				'onclick="toggleElement(this.parentNode.parentNode.getElementsByClassName(\'result-extra\')[0])">' +
+				'&#8862;</span>&nbsp;' + basicText;
 		}
+
+		return '<div class="result">' +
+				'<div class="result-basic">' + basicText + '</div>' +
+				'<div class="result-extra">' + makeTable(extraData) + '</div>' +
+				'<pre class="result-code">' + code + '</pre>' +
+			'</div>';
+	}
+
+	var makeResultHTML = function (result) {
+		var kind = result[0];
+		var basic = result[1][0];
+		var extra = result[1][1];
+
+		var extraData = [];
 
 		switch (kind) {
 			case 'FunctionResult':
-				var specificData = [];
-				specificData.push(
-					('cls' in specific ?
+				if ('cls' in extra)
+					extraData.push(
 						[ 'Class', '<code>' +
-						  highlightClassDef(specific['cls']['cls_name'] +
-							  ' ' + specific['cls']['cls_vars'].join(' '),
-							  highlightCallback, 'className') + '</code>'] :
-						[]),
-					('unifier' in specific &&
-						(specific['unifier'][0].length > 0 ||
-						 specific['unifier'][1].length > 0) ?
-						['Unifier', makeUnifier(specific['unifier'])] :
-						[])
-				);
-				if ('generic_derivations' in specific) {
-					var derivationsId = 'derivations-' + (derivationsIdCounter++);
+						  highlightClassDef(extra['cls']['cls_name'] +
+							  ' ' + extra['cls']['cls_vars'].join(' '),
+							  highlightCallback, 'className') + '</code>']);
+
+				if ('unifier' in extra &&
+					(extra['unifier'][0].length > 0 || extra['unifier'][1].length > 0))
+					extraData.push(['Unifier', makeUnifier(extra['unifier'])]);
+
+				if ('generic_derivations' in extra) {
 					var derivations = makeInstanceTable(
-							derivationsId,
-							specific['generic_derivations'],
+							extra['generic_derivations'],
 							highlightType);
-					specificData.push(['Derivations', derivations]);
+					extraData.push(['Derivations', derivations]);
 				}
+
 				var hl_entry = 'start';
-				if ('constructor_of' in specific) {
-					specificData.push([
-						'This function is a type constructor of <code>' +
-						highlightFunction(':: ' + specific['constructor_of'],
+				if ('constructor_of' in extra) {
+					extraData.push([
+						'This is a type constructor of <code>' +
+						highlightFunction(':: ' + extra['constructor_of'],
 							highlightCallback) + '</code>.'
 					]);
 					hl_entry = 'startConstructor';
-				} else if ('recordfield_of' in specific) {
-					specificData.push([
+				} else if ('recordfield_of' in extra) {
+					extraData.push([
 						'This is a record field of <code>' +
-						highlightFunction(':: ' + specific['recordfield_of'],
+						highlightFunction(':: ' + extra['recordfield_of'],
 							highlightCallback) + '</code>.'
 					]);
 					hl_entry = 'startRecordField';
 				}
-				return '<hr/>' +
-					makeTable(basicData.concat(specificData)) +
-					'<pre>' +
-					highlightFunction(specific['func'], highlightCallback, hl_entry) +
-					'</pre>';
-				break;
+
+				return makeGenericResultHTML(basic, extraData,
+						highlightFunction(extra['func'], highlightCallback, hl_entry));
+
 			case 'TypeResult':
-				var specificData = [];
-				if (specific['type_instances'].length > 0) {
-					var instancesId = 'instances-' + (instancesIdCounter++);
-					specificData.push(['Instances',
+				if (extra['type_instances'].length > 0) {
+					extraData.push(['Instances',
 							makeInstanceTable(
-								instancesId,
-								specific['type_instances'],
+								extra['type_instances'],
 								highlightClassDef, 'className')]);
 				}
-				if (specific['type_derivations'].length > 0) {
-					var derivationsId = 'derivations-' + (derivationsIdCounter++);
-					specificData.push(['Derivations',
+
+				if (extra['type_derivations'].length > 0) {
+					extraData.push(['Derivations',
 							makeInstanceTable(
-								derivationsId,
-								specific['type_derivations'],
+								extra['type_derivations'],
 								highlightFunction, 'generic')]);
 				}
-				return '<hr/>' +
-					makeTable(basicData) +
-					'<pre>' +
-					highlightTypeDef(specific['type'], highlightCallback) +
-					'</pre>' +
-					makeTable(specificData);
-				break;
+
+				return makeGenericResultHTML(basic, extraData,
+						highlightTypeDef(extra['type'], highlightCallback));
+
 			case 'ClassResult':
-				var instancesId = 'instances-' + (instancesIdCounter++);
 				var instances = makeInstanceTable(
-						instancesId,
-						specific['class_instances'],
+						extra['class_instances'],
 						highlightType);
-				var specificData = [['Instances', instances]];
-				var html = '<hr/>' +
-					makeTable(basicData) + '<pre>' +
-					highlightClassDef(
-							'class ' + specific['class_heading'] +
-							(specific['class_funs'].length > 0 ? ' where' : ''),
-							highlightCallback);
-				for (var i in specific['class_funs']) {
+				extraData.push(['Instances', instances]);
+
+				var html = highlightClassDef(
+						'class ' + extra['class_heading'] +
+						(extra['class_funs'].length > 0 ? ' where' : ''),
+						highlightCallback) + '\n';
+				for (var i in extra['class_funs'])
 					html += highlightFunction(
-							'\n\n\t' + specific['class_funs'][i].replace(/\n/g, '\n\t'),
+							'\n    ' + extra['class_funs'][i].replace(/\n/g, '\n    '),
 							highlightCallback, 'macro');
-				}
-				html += '</pre>';
-				html += makeTable(specificData);
-				return html;
-				break;
+
+				return makeGenericResultHTML(basic, extraData, html);
+
 			case 'MacroResult':
-				return '<hr/>' +
-					makeTable(basicData) +
-					'<pre>' +
-					highlightFunction(specific['macro_representation'], highlightCallback, 'macro') +
-					'</pre>';
-				break;
+				return makeGenericResultHTML(basic, [],
+						highlightFunction(extra['macro_representation'], highlightCallback, 'macro'));
+
 			case 'ModuleResult':
-				specificData = [];
-				if (specific['module_is_core'])
-					specificData.push(['<span class="core-module">' +
+				if (extra['module_is_core'])
+					extraData.push(['<span class="core-module">' +
 							'This is a core module and should usually only be used internally.' +
 							'</span>']);
-				return '<hr/>' + makeTable(basicData) +
-					'<pre>' + highlightFunction('import ' + basic['modul']) + '</pre>' +
-					makeTable(specificData);
-				break;
+
+				return makeGenericResultHTML(basic, extraData,
+						highlightFunction('import ' + basic['modul']));
+
 			default:
 				return '';
 		}

--- a/frontend/api.js
+++ b/frontend/api.js
@@ -12,6 +12,10 @@ var old_libs = null;
 var old_include_builtins = null;
 var old_include_core = null;
 
+function pluralise(n, what) {
+	return n + ' ' + what + (n == 1 ? '' : 's');
+}
+
 function toggleElement(e) {
 	e.style.display = e.style.display == 'block' ? 'none' : 'block';
 }
@@ -289,7 +293,7 @@ function getResults(str, libs, include_builtins, include_core, page) {
 							extra['generic_derivations'],
 							highlightType);
 					extraData.push(['Derivations', derivations,
-							extra['generic_derivations'].length + ' derivations']);
+							pluralise(extra['generic_derivations'].length, 'derivation')]);
 				}
 
 				var hl_entry = 'start';
@@ -314,27 +318,31 @@ function getResults(str, libs, include_builtins, include_core, page) {
 
 			case 'TypeResult':
 				if (extra['type_instances'].length > 0) {
-					extraData.push(['Instances',
+					extraData.push([
+							'Instances',
 							makeInstanceTable(
 								extra['type_instances'],
-								highlightClassDef, 'className')]);
+								highlightClassDef, 'className'),
+							pluralise(extra['type_instances'].length, 'instance')]);
 				}
 
 				if (extra['type_derivations'].length > 0) {
-					extraData.push(['Derivations',
+					extraData.push([
+							'Derivations',
 							makeInstanceTable(
 								extra['type_derivations'],
-								highlightFunction, 'generic')]);
+								highlightFunction, 'generic'),
+							pluralise(extra['type_derivations'].length, 'derivation')]);
 				}
 
 				return makeGenericResultHTML(basic, extraData,
 						highlightTypeDef(extra['type'], highlightCallback));
 
 			case 'ClassResult':
-				var instances = makeInstanceTable(
-						extra['class_instances'],
-						highlightType);
-				extraData.push(['Instances', instances]);
+				extraData.push([
+						'Instances',
+						makeInstanceTable(extra['class_instances'], highlightType),
+						pluralise(extra['class_instances'].length, 'instance')]);
 
 				var html = highlightClassDef(
 						'class ' + extra['class_heading'] +

--- a/frontend/frontend.css
+++ b/frontend/frontend.css
@@ -57,23 +57,29 @@ th {
 	color: #26c;
 }
 
+.toggle-container .toggler {
+	cursor: pointer;
+}
+
+.toggle-container .togglee {
+	display: none;
+}
+
 .result-basic {
 	background-color: #f0f0f0;
 	padding: .2em;
 }
 
-.result-basic .more {
-	color: #444;
-	cursor: pointer;
-}
-
 .result-extra {
-	background-color: #e8e8e8;
-	display: none;
+	background-color: #f8f8f8;
 	font-size: 85%;
 	padding-left: 1.2em;
 }
 
+.result-extra .toggler {
+	margin-left: -1em;
+}
+
 .result-code {
-	margin: .5em 0 1.5em 1em;
+	margin: 1em 0 1.5em 1em;
 }

--- a/frontend/frontend.css
+++ b/frontend/frontend.css
@@ -1,3 +1,7 @@
+body {
+	color: #222;
+}
+
 #helptext {
 	margin-bottom: 1em;
 }
@@ -43,4 +47,33 @@ th {
 
 .core-module {
 	font-style: italic;
+}
+
+#search_results {
+	margin-top: 1.5em;
+}
+
+#search_results a {
+	color: #26c;
+}
+
+.result-basic {
+	background-color: #f0f0f0;
+	padding: .2em;
+}
+
+.result-basic .more {
+	color: #444;
+	cursor: pointer;
+}
+
+.result-extra {
+	background-color: #e8e8e8;
+	display: none;
+	font-size: 85%;
+	padding-left: 1.2em;
+}
+
+.result-code {
+	margin: .5em 0 1.5em 1em;
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -18,11 +18,11 @@
 			<img src="logo.jpg" alt="follow link for the sourcecode" />
 		</a>
 	</p>
-	<p>Cloogle is the unofficial <a href="http://clean.cs.ru.nl">Clean</a> language search engine.</p>
 	<p>
 		<a href="javascript:toggle('helptext')">How to use</a> | <a href="javascript:toggle('contributetext')">Contribute</a>
 	</p>
 	<div id="helptext" style="display:none;">
+		<p>Cloogle is the unofficial <a href="http://clean.cs.ru.nl">Clean</a> language search engine.</p>
 		<p><b>The following search strings are recognised:</b></p>
 		<table>
 			<tr>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -19,7 +19,7 @@
 		</a>
 	</p>
 	<p>
-		<a href="javascript:toggle('helptext')">How to use</a> | <a href="javascript:toggle('contributetext')">Contribute</a>
+		<a href="javascript:toggleById('helptext')">How to use</a> | <a href="javascript:toggleById('contributetext')">Contribute</a>
 	</p>
 	<div id="helptext" style="display:none;">
 		<p>Cloogle is the unofficial <a href="http://clean.cs.ru.nl">Clean</a> language search engine.</p>


### PR DESCRIPTION
This implements many ideas from #88, except for fiddling with the header.

One thing that I'm not sure about is that when there is only one piece of 'more information', like only a unifier, the 'more information' link could be removed and the unifier could be put instead (i.e., only put the link when there is more than one piece of information / when it is a list of instances or derivations). However, removing the more information link in some cases may work confusing.

Another option is to only hide instances and derivations behind the more link (but both behind one link would have my preference, so that you don't need to click twice).