### PR TITLE
remove png version

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -35,10 +35,3 @@ RUN hg clone https://bitbucket.org/camilstaps/pygments-main-3 /opt/pygments \
 
 COPY iconv.sh .
 RUN bash iconv.sh && rm iconv.sh
-
-COPY logo.svg /var/www/logo.svg
-RUN cd /var/www \
-	&& apt-get install -qq inkscape \
-	&& inkscape logo.svg -w 200 --export-png=logo.png \
-	&& apt-get remove -qq inkscape \
-	&& apt-get autoremove -qq

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -18,7 +18,7 @@
 	<div id="header">
 		<div id="logo">
 			<a href="https://github.com/clean-cloogle/cloogle">
-				<img src="logo.png" alt="follow link for the sourcecode" />
+				<img src="logo.svg" alt="follow link for the sourcecode" />
 			</a>
 		</div>
 		<div id="search">

--- a/frontend/logo.svg
+++ b/frontend/logo.svg
@@ -7,9 +7,8 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="433.16434"
-   height="200"
-   viewBox="0 0 114.60806 52.916668"
+   width="200"
+   viewBox="0 0 117 54"
    version="1.1"
    id="clooglelogo">
   <title


### PR DESCRIPTION
- removes dependency
- lowers bandwidth usage
- improves scalability when people want to zoom in on the logo