### PR TITLE
Search syntax

### DIFF
--- a/backend/BuiltinSyntax.dcl
+++ b/backend/BuiltinSyntax.dcl
@@ -1,0 +1,5 @@
+definition module BuiltinSyntax
+
+from CloogleDB import :: SyntaxEntry, :: SyntaxResultExtras
+
+builtin_syntax :: [([String], SyntaxEntry)]

--- a/backend/BuiltinSyntax.dcl
+++ b/backend/BuiltinSyntax.dcl
@@ -1,5 +1,0 @@
-definition module BuiltinSyntax
-
-from CloogleDB import :: SyntaxEntry, :: SyntaxResultExtras
-
-builtin_syntax :: [([String], SyntaxEntry)]

--- a/backend/BuiltinSyntax.icl
+++ b/backend/BuiltinSyntax.icl
@@ -1,6 +1,9 @@
 implementation module BuiltinSyntax
 
+import StdBool
+import StdEnum
 import StdInt
+import StdList
 import StdOverloaded
 import StdString
 
@@ -12,18 +15,32 @@ import CloogleDB
 
 builtin_syntax :: [([String], SyntaxEntry)]
 builtin_syntax =
+	  bs_arrays ++
 	[ bs_case
+	, bs_define_constant
+	, bs_define_graph
+	, bs_dotdot
+	, bs_exists
+	, bs_forall
 	, bs_import
 	, bs_infix
 	, bs_let
 	, bs_let_before
-	, bs_module
+	] ++ bs_lists ++
+	[ bs_module
 	, bs_otherwise
+	// TODO bs_selection (arrays and records)
 	, bs_strict
+	, bs_synonym
+	, bs_synonym_abstract
+	] ++ bs_tuples ++
+	[ bs_update_array
+	, bs_update_record
 	, bs_where_class
 	, bs_where_instance
 	, bs_where_local
 	, bs_with
+	// TODO bs_zf
 	]
 
 CLR :: Int String String -> SyntaxDocLocation
@@ -40,6 +57,23 @@ EX t c = {example=c, cleanjs_type=t, cleanjs_start=Nothing}
 EXs :: String String String -> SyntaxExample
 EXs t s c = {example=c, cleanjs_type=t, cleanjs_start=Just s}
 
+bs_arrays = [make_array kind \\ kind <- [[], ['!'], ['#']]]
+where
+	make_array :: [Char] -> ([SyntaxPattern], SyntaxEntry)
+	make_array k = (["array", typec, toString (['{':k]++['\\w}'])],
+		{ syntax_title        = kind + "array"
+		, syntax_code         = [typec]
+		, syntax_description  = "An array contains a finite number of elements of the same type. Access time is constant."
+		, syntax_doc_location = [CLR 6 "4.4" "_Toc311798029"]
+		, syntax_examples     = [EX "Function" ("xs :: {" <+ k <+ "Int}\nxs = {" <+ k <+ "1,3,6,10}")]
+		})
+	where
+		typec = toString (['{':k]++['}'])
+		kind = case k of
+			[]    -> ""
+			['!'] -> "strict "
+			['#'] -> "unboxed "
+
 bs_case = (["case", "of", "case of"],
 	{ syntax_title        = "case expression"
 	, syntax_code         = ["case ... of ..."]
@@ -50,28 +84,88 @@ bs_case = (["case", "of", "case of"],
 		]
 	})
 
+bs_define_constant = (["=:"],
+	{ syntax_title        = "graph definition"
+	, syntax_code         = ["... =: ..."]
+	, syntax_description  =
+		"Defining constants with `=:` at the top level makes sure they are shared through out the program; hence, they are evaluated only once.\n" +
+		"This is the default understanding of `=` in local scope.\n" +
+		"The inverse is {{`=>`}}, which defines an identifier to be a constant function."
+	, syntax_doc_location = [CLR 5 "3.6" "_Toc311798007"]
+	, syntax_examples     = [EXs "Function" "macro" "mylist =: [1..10000]"]
+	})
+bs_define_graph = (["=>"],
+	{ syntax_title        = "constant function definition"
+	, syntax_code         = ["... => ..."]
+	, syntax_description  =
+		"Defining constants with `=>` at the top level makes sure they are interpreted as constant functions; hence, they are evaluated every time they are needed.\n" +
+		"This is the default understanding of `=` in global scope.\n" +
+		"The inverse is {{`=:`}}, which defines an identifier to be a graph."
+	, syntax_doc_location = [CLR 5 "3.6" "_Toc311798007"]
+	, syntax_examples     = [EXs "Function" "macro" "mylist => [1..10000]"]
+	})
+
+bs_dotdot = (["[\\e..]", "[\\e..\e]", "[\\e,\\e..]", "[[\\e,\\e..\\e]", "dotdot", "dot-dot"],
+	{ syntax_title        = "dotdot expression"
+	, syntax_code         = ["[i..]", "[i..k]", "[i,j..]", "[i,j..k]"]
+	, syntax_description  =
+		"A shorthand for lists of enumerable types.\n" +
+		"To use these expressions, you must import {{`StdEnum`}}. The underlying functions are defined in {{`_SystemEnum`}}."
+	, syntax_doc_location = [CLR 6 "4.2.1" "_Toc311798023"]
+	, syntax_examples     = map (EXs "Function" "macro")
+		[ "xs = [0..]     // 0, 1, 2, 3, ..."
+		, "xs = [0,2..]   // 0, 2, 4, 6, ..."
+		, "xs = [0..10]   // 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10"
+		, "xs = [0,2..10] // 0, 2, 4, 6, 8, 10"
+		]
+	})
+
+bs_exists = (["E", "E.*"],
+	{ syntax_title        = "existential quantifier"
+	, syntax_code         = [":: ... = E. ...: ..."]
+	, syntax_description  = "Existential quantifiers make it possible to define (recursive) objects of the same type with different types of content."
+	, syntax_doc_location = [CLR 7 "5.1.3" "_Toc311798042"]
+	, syntax_examples     = [EX "Function" ":: List = E.e: Cons e List | Nil\nStart = Cons 5 (Cons 'a' (Cons \"abc\" Nil))"] // TODO highlighting
+	})
+
+bs_forall = (["A", "A.*"],
+	{ syntax_title        = "universal quantifier"
+	, syntax_code         = ["A. ...:"]
+	, syntax_description  = "Explicitly marks polymorphic type variables. Clean does not yet allow universal quantifiers on the topmost level."
+	, syntax_doc_location = [CLR 5 "3.7.4" "_Toc311798013"]
+	, syntax_examples     = map (EX "Function")
+		[ "hd :: A.a: [a] -> a           // Not yet allowed: A. on the topmost level"
+		, "h :: (A.a: [a] -> Int) -> Int // The quantifier is needed to apply the function to both a [Int] and a [Char]\nh f = f [1..100] + f ['a'..'z']"
+		]
+	})
+
 bs_import = (["import", "from", "qualified", "as"],
 	{ syntax_title        = "imports"
 	, syntax_code         = ["import [qualified] ... [as ...]", "from ... import ..."]
-	, syntax_description  = "Imports code from other modules. With the `from` keyword, one can achieve more granularity. In case of name clashes, `qualified` can be used (undocumented)."
+	, syntax_description  =
+		"Imports code from other modules.\n" +
+		"With the `from` keyword, one can achieve more granularity.\n" +
+		"In case of name clashes, `qualified` can be used (undocumented)."
 	, syntax_doc_location = [CLR 4 "2.5" "_Toc311797991"]
-	, syntax_examples     =
-		[ EX "Function" "import ..."
-		, EX "Function" "import StdEnv                  // Import all code from the StdEnv definition module"
-		, EX "Function" "from StdFunc import o          // Import only the o function from StdFunc"
-		, EX "Function" "import qualified Data.Map as M // Import Data.Map such that functions are available as e.g. 'M'.get."
+	, syntax_examples     = map (EX "Function")
+		[ "import ..."
+		, "import StdEnv                  // Import all code from the StdEnv definition module"
+		, "from StdFunc import o          // Import only the o function from StdFunc"
+		, "import qualified Data.Map as M // Import Data.Map such that functions are available as e.g. 'M'.get."
 		]
 	})
 
 bs_infix = (["infix", "infixl", "infixr"],
 	{ syntax_title        = "infix operator"
-	, syntax_code         = ["infix[l,r]"]
-	, syntax_description  = "Defines a function with arity 2 that can be used in infix position. `n` determines the precedence. `infixl` and `infixr` indicate associativity."
+	, syntax_code         = ["infix[l,r] [...]"]
+	, syntax_description  =
+		"Defines a function with arity 2 that can be used in infix position.\n" +
+		"The following number, if any, determines the precedence.\n" +
+		"`infixl` and `infixr` indicate associativity."
 	, syntax_doc_location = [CLR 5 "3.7.2" "_Toc311798011"]
 	, syntax_examples     =
-		[ EX  "Function"         "(...) infix n :: ..."
-		, EX  "Function"         "(bitor) infixl 6 :: !Int !Int -> Int // Left-associative infix function with precedence 6"
-		, EXs "Function" "macro" "(o) infixr 9                         // Infix macro\n(o) f g :== \x -> f (g x)"
+		[ EX  "Function"         "(bitor) infixl 6 :: !Int !Int -> Int // Left-associative infix function with precedence 6"
+		, EXs "Function" "macro" "(o) infixr 9                         // Infix macro\n(o) f g :== \\x -> f (g x)"
 		, EX  "TypeDef"          ":: MyType = (:+:) infixl 6 Int Int   // Infix data constructor, can be used as (5 :+: 10)"
 		]
 	})
@@ -89,12 +183,46 @@ bs_let = (["let", "in", "let in"],
 bs_let_before = (["#", "#!"],
 	{ syntax_title        = "let before"
 	, syntax_code         = ["#  ... = ...", "#! ... = ..."]
-	, syntax_description  = "A let expression that can be defined before a guard or function body, which eases the syntax of sequential actions."
+	, syntax_description  = "A {{`let`}} expression that can be defined before a guard or function body, which eases the syntax of sequential actions."
 	, syntax_doc_location = [CLR 5 "3.5.4" "_Toc311798006"]
 	, syntax_examples     =
 		[ EX "Function" "readchars :: *File -> *([Char], *File)\nreadchars f\n# (ok,c,f) = freadc file\n| not ok   = ([], f)\n# (cs,f)   = readchars f\n= ([c:cs], f)"
 		]
 	})
+
+bs_lists = [make_list kind spine \\ kind <- [[], ['#'], ['!'], ['|']], spine <- [[], ['!']] | kind <> ['|'] || spine <> ['!']]
+where
+	make_list :: [Char] [Char] -> ([SyntaxPattern], SyntaxEntry)
+	make_list k s = ([higherorder, listany, "list"],
+		{ syntax_title        = "lists"
+		, syntax_code         = [higherorder]
+		, syntax_description  = "A" + kind + spine + " list.\n\n" + description
+		, syntax_doc_location = [CLR 6 "4.2" "_Toc311798019"]
+		, syntax_examples     = map (EXs "Function" "macro") ["f :: " <+ lista <+ " -> a", "ints = " <+ listints]
+		})
+	where
+		higherorder = toString (['[':k] ++ s` ++ [']'])
+			with s` = if (s == ['!'] && k == []) [' !'] s
+		lista       = toString (['[':k] ++ ['a':s] ++ [']'])
+		listints    = toString (['[':k] ++ ['1,1,2,3,5':s] ++ [']'])
+		listany     = toString (['[':k] ++ ['\\','w':s] ++ [']'])
+		kind = case k of
+			[]    ->  " normal"
+			['#'] -> "n unboxed"
+			['!'] ->  " head strict"
+			['|'] -> "n overloaded"
+		spine = case s of
+			[]    -> ""
+			['!'] -> " spine strict"
+
+		description = "These types of list are available:\n" +
+			"- {{`[a]`}}, a normal list\n" +
+			"- {{`[#a]`}}, an unboxed head-strict list (elements are stored directly, without pointers)\n" +
+			"- {{`[!a]`}}, a head-strict list (the first element is in root normal form)\n" +
+			"- {{`[a!]`}}, a spine-strict list (the last element is known)\n" +
+			"- {{`[#a!]`}}, an unboxed spine-strict list\n" +
+			"- {{`[!a!]`}}, a head-strict spine-strict list\n" +
+			"- {{`[|a]`}}, an overloaded list (one of the types above)"
 
 bs_module = (["module", "definition", "implementation", "system", "definition module", "implementation module", "system module"],
 	{ syntax_title        = "module heading"
@@ -129,24 +257,74 @@ bs_strict = (["strict", "!"],
 	, syntax_examples     = [EX "Function" "acker :: !Int !Int -> Int"]
 	})
 
+bs_synonym = (["synonym", ":=="],
+	{ syntax_title        = "synonym type definition"
+	, syntax_code         = [":: ... :== ..."]
+	, syntax_description  = "Defines a new type name for an existing type."
+	, syntax_doc_location = [CLR 7 "5.3" "_Toc311798052"]
+	, syntax_examples     = [EX "TypeDef" ":: String :== {#Char}"]
+	})
+bs_synonym_abstract = (["synonym", ":=="],
+	{ syntax_title        = "abstract synonym type definition"
+	, syntax_code         = [":: ... (:== ...)"]
+	, syntax_description  = "Defines a new type name for an existing type, while the type behaves as an abstract type for the programmer. This allows compiler optimisations on abstract types."
+	, syntax_doc_location = [CLR 7 "5.4.1" "_Toc311798054"]
+	, syntax_examples     = [EX "TypeDef" ":: Stack a (:== [a])"]
+	})
+
+bs_tuples = [make_tuple n \\ n <- [1..31]]
+where
+	make_tuple :: Int -> ([SyntaxPattern], SyntaxEntry)
+	make_tuple n = ([toString ['(':repeatn n ','++[')']], withargs, "tuple"],
+		{ syntax_title        = ary + "ary tuple"
+		, syntax_code         = [withvars]
+		, syntax_description  =
+			"Tuples allow bundling a finite number of expressions of different types into one object without defining a new data type.\n" +
+			"Clean supports tuples of arity 2 to 32."
+		, syntax_doc_location = [CLR 6 "4.3" "_Toc311798026"]
+		, syntax_examples     = []
+		})
+	where
+		withargs = toString ['(\\w':foldl (++) [] [[',\\w'] \\ _ <- [1..n]] ++ [')']]
+		withvars = toString ['(a'  :foldl (++) [] [[',':v]  \\ _ <- [1..n] & v <- map (\x->[x]) ['b'..'z'] ++ [[v,'`'] \\ v <- ['a'..]]] ++ [')']]
+		ary = case n of
+			1 -> "bin"
+			2 -> "tren"
+			n -> n+1 <+ "-"
+
+bs_update_array = (["&", "{*&*[\\e]*=*}"],
+	{ syntax_title        = "array update"
+	, syntax_code         = ["{ a & [i]=x, [j]=y, ... } // Updates a by setting index i to x, j to y, ..."]
+	, syntax_description  = "Updates an array by creating a copy and replacing one or more elements"
+	, syntax_doc_location = [CLR 6 "4.4.1" "_Toc311798032"]
+	, syntax_examples     = []
+	})
+bs_update_record = (["&", "{*&*=*}"],
+	{ syntax_title        = "record update"
+	, syntax_code         = ["{ r & f1=x, f2=y, ... } // Updates r by setting f1 to x, f2 to y, ..."]
+	, syntax_description  = "Updates a record by creating a copy and replacing one or more fields"
+	, syntax_doc_location = [CLR 7 "5.2.1" "_Toc311798049"]
+	, syntax_examples     = []
+	})
+
 bs_where_class = (["where"],
 	{ syntax_title        = "where"
 	, syntax_code         = ["where"]
-	, syntax_description  = "Introduces the members of a class definition."
+	, syntax_description  = "Introduces the members of a {{`class`}} definition."
 	, syntax_doc_location = [CLR 8 "6.1"   "_Toc311798056"]
 	, syntax_examples     = [EX "ClassDef" "class Arith a        // Class definition\nwhere\n\t(+) infixl 6 :: a a -> a\n\t(-) infixl 6 :: a a -> a"] // TODO highlighting
 	})
 bs_where_instance = (["where"],
 	{ syntax_title        = "where"
 	, syntax_code         = ["where"]
-	, syntax_description  = "Introduces the implementation of an instance."
+	, syntax_description  = "Introduces the implementation of an {{`instance`}}."
 	, syntax_doc_location = [CLR 8 "6.1"   "_Toc311798056"]
 	, syntax_examples     = [EX "Function" "instance Arith Int   // Instance definition\nwhere\n\t(+) x y = // ...\n\t(-) x y = // ..."]
 	})
 bs_where_local = (["where"],
 	{ syntax_title        = "where"
 	, syntax_code         = ["where"]
-	, syntax_description  = "Introduces local definitions."
+	, syntax_description  = "Introduces local definitions. For guard-local definitions, see {{`with`}}."
 	, syntax_doc_location = [CLR 5 "3.5.2" "_Toc311798004"]
 	, syntax_examples     = [EXs "Function" "macro" "primes = sieve [2..] // Local definitions\nwhere\n\tsieve [pr:r] = [pr:sieve (filter pr r)]"]
 	})
@@ -154,7 +332,7 @@ bs_where_local = (["where"],
 bs_with = (["with"],
 	{ syntax_title        = "with"
 	, syntax_code         = ["with"]
-	, syntax_description  = "Introduces guard-local definitions."
+	, syntax_description  = "Introduces guard-local definitions. For function-local definitions, see {{`where`}}."
 	, syntax_doc_location = [CLR 5 "3.5.3" "_Toc311798005"]
 	, syntax_examples     = [EXs "Function" "macro" "f x y\n| guard1 = alt1\n\twith local = expr1\n| guard2 = alt2\n\twith local = expr2"]
 	})

--- a/backend/BuiltinSyntax.icl
+++ b/backend/BuiltinSyntax.icl
@@ -80,7 +80,7 @@ bs_let = (["let", "in", "let in"],
 	{ syntax_title        = "let expression"
 	, syntax_code         = ["let ... in ..."]
 	, syntax_description  = "An expression that introduces new scope."
-	, syntax_doc_location = [CLR 5 "3.5.1" "_Toc31178003"]
+	, syntax_doc_location = [CLR 5 "3.5.1" "_Toc311798003"]
 	, syntax_examples     =
 		[ EXs "Function" "macro"    "fac n = let fs = [1:1:[(fs!!(i-1)) + (fs!!(i-2)) \\ i <- [2..]]] in fs !! n"
 		, EXs "Function" "macrorhs" "let // Multi-line let expressions\n\tfunction args = body\n\tselector = expr\n\t// ...\nin expression"

--- a/backend/BuiltinSyntax.icl
+++ b/backend/BuiltinSyntax.icl
@@ -1,0 +1,160 @@
+implementation module BuiltinSyntax
+
+import StdInt
+import StdOverloaded
+import StdString
+
+import Data.Maybe
+import Text
+
+import Cloogle
+import CloogleDB
+
+builtin_syntax :: [([String], SyntaxEntry)]
+builtin_syntax =
+	[ bs_case
+	, bs_import
+	, bs_infix
+	, bs_let
+	, bs_let_before
+	, bs_module
+	, bs_otherwise
+	, bs_strict
+	, bs_where_class
+	, bs_where_instance
+	, bs_where_local
+	, bs_with
+	]
+
+CLR :: Int String String -> SyntaxDocLocation
+CLR f sec h = CleanLangReport
+	{ clr_version = v
+	, clr_file    = "CleanRep." + v + "_" <+ f <+ ".htm"
+	, clr_section = sec
+	, clr_heading = h
+	}
+where v = "2.2"
+
+EX :: String String -> SyntaxExample 
+EX t c = {example=c, cleanjs_type=t, cleanjs_start=Nothing}
+EXs :: String String String -> SyntaxExample
+EXs t s c = {example=c, cleanjs_type=t, cleanjs_start=Just s}
+
+bs_case = (["case", "of", "case of"],
+	{ syntax_title        = "case expression"
+	, syntax_code         = ["case ... of ..."]
+	, syntax_description  = "Pattern match on an expression and do something depending on the alternative of the matching pattern."
+	, syntax_doc_location = [CLR 5 "3.4.2" "_Toc311798001"]
+	, syntax_examples     =
+		[ EXs "Function" "macro" "isJust m = case m of\n\tJust _ -> True\n\t_      -> False"
+		]
+	})
+
+bs_import = (["import", "from", "qualified", "as"],
+	{ syntax_title        = "imports"
+	, syntax_code         = ["import [qualified] ... [as ...]", "from ... import ..."]
+	, syntax_description  = "Imports code from other modules. With the `from` keyword, one can achieve more granularity. In case of name clashes, `qualified` can be used (undocumented)."
+	, syntax_doc_location = [CLR 4 "2.5" "_Toc311797991"]
+	, syntax_examples     =
+		[ EX "Function" "import ..."
+		, EX "Function" "import StdEnv                  // Import all code from the StdEnv definition module"
+		, EX "Function" "from StdFunc import o          // Import only the o function from StdFunc"
+		, EX "Function" "import qualified Data.Map as M // Import Data.Map such that functions are available as e.g. 'M'.get."
+		]
+	})
+
+bs_infix = (["infix", "infixl", "infixr"],
+	{ syntax_title        = "infix operator"
+	, syntax_code         = ["infix[l,r]"]
+	, syntax_description  = "Defines a function with arity 2 that can be used in infix position. `n` determines the precedence. `infixl` and `infixr` indicate associativity."
+	, syntax_doc_location = [CLR 5 "3.7.2" "_Toc311798011"]
+	, syntax_examples     =
+		[ EX  "Function"         "(...) infix n :: ..."
+		, EX  "Function"         "(bitor) infixl 6 :: !Int !Int -> Int // Left-associative infix function with precedence 6"
+		, EXs "Function" "macro" "(o) infixr 9                         // Infix macro\n(o) f g :== \x -> f (g x)"
+		, EX  "TypeDef"          ":: MyType = (:+:) infixl 6 Int Int   // Infix data constructor, can be used as (5 :+: 10)"
+		]
+	})
+
+bs_let = (["let", "in", "let in"],
+	{ syntax_title        = "let expression"
+	, syntax_code         = ["let ... in ..."]
+	, syntax_description  = "An expression that introduces new scope."
+	, syntax_doc_location = [CLR 5 "3.5.1" "_Toc31178003"]
+	, syntax_examples     =
+		[ EXs "Function" "macro"    "fac n = let fs = [1:1:[(fs!!(i-1)) + (fs!!(i-2)) \\ i <- [2..]]] in fs !! n"
+		, EXs "Function" "macrorhs" "let // Multi-line let expressions\n\tfunction args = body\n\tselector = expr\n\t// ...\nin expression"
+		]
+	})
+bs_let_before = (["#", "#!"],
+	{ syntax_title        = "let before"
+	, syntax_code         = ["#  ... = ...", "#! ... = ..."]
+	, syntax_description  = "A let expression that can be defined before a guard or function body, which eases the syntax of sequential actions."
+	, syntax_doc_location = [CLR 5 "3.5.4" "_Toc311798006"]
+	, syntax_examples     =
+		[ EX "Function" "readchars :: *File -> *([Char], *File)\nreadchars f\n# (ok,c,f) = freadc file\n| not ok   = ([], f)\n# (cs,f)   = readchars f\n= ([c:cs], f)"
+		]
+	})
+
+bs_module = (["module", "definition", "implementation", "system", "definition module", "implementation module", "system module"],
+	{ syntax_title        = "module heading"
+	, syntax_code         = ["[definition,implementation,system] module ..."]
+	, syntax_description  = "The heading of a Clean file. Definition modules describe what things are exported (dcl files), implementation modules how they are implemented (icl files)."
+	, syntax_doc_location = [CLR 4 "2.2" "_Toc311797983"]
+	, syntax_examples     =
+		[ EX "Function" "definition module ..."
+		, EX "Function" "definition module StdList     // Exported definitions of list functions"
+		, EX "Function" "implementation module StdList // The implementations of the functions"
+		, EX "Function" "module test                   // An implementation module without corresponding dcl"
+		, EX "Function" "system module StdInt          // The definitions of a module that contains foreign code (see section 2.6 of the language report)"
+		]
+	})
+
+bs_otherwise = (["otherwise"],
+	{ syntax_title        = "otherwise"
+	, syntax_code         = ["otherwise"]
+	, syntax_description  = "The (optional) last alternative in a guard. It caches all other cases, and makes sure your program does not crash if none of the cases matches."
+	, syntax_doc_location = [CLR 5 "3.3" "_Toc311797998"]
+	, syntax_examples     =
+		[ EXs "Function" "macrorhs" "| otherwise = ..."
+		, EXs "Function" "macro"    "sign :: !Int -> Int\nsign n\n| n  < 0    = -1 // Negative number\n| n == 0    =  0 // Zero\n| otherwise =  1 // Must be positive"
+		]
+	})
+
+bs_strict = (["strict", "!"],
+	{ syntax_title        = "strictness annotation"
+	, syntax_code         = ["!"]
+	, syntax_description  = "Override the lazy evaluation strategy: the argument must be evaluated to head normal form before the function is entered."
+	, syntax_doc_location = [CLR 5 "3.7.5" "_Toc311798014", CLR 12 "10" "_Toc311798103"]
+	, syntax_examples     = [EX "Function" "acker :: !Int !Int -> Int"]
+	})
+
+bs_where_class = (["where"],
+	{ syntax_title        = "where"
+	, syntax_code         = ["where"]
+	, syntax_description  = "Introduces the members of a class definition."
+	, syntax_doc_location = [CLR 8 "6.1"   "_Toc311798056"]
+	, syntax_examples     = [EX "ClassDef" "class Arith a        // Class definition\nwhere\n\t(+) infixl 6 :: a a -> a\n\t(-) infixl 6 :: a a -> a"] // TODO highlighting
+	})
+bs_where_instance = (["where"],
+	{ syntax_title        = "where"
+	, syntax_code         = ["where"]
+	, syntax_description  = "Introduces the implementation of an instance."
+	, syntax_doc_location = [CLR 8 "6.1"   "_Toc311798056"]
+	, syntax_examples     = [EX "Function" "instance Arith Int   // Instance definition\nwhere\n\t(+) x y = // ...\n\t(-) x y = // ..."]
+	})
+bs_where_local = (["where"],
+	{ syntax_title        = "where"
+	, syntax_code         = ["where"]
+	, syntax_description  = "Introduces local definitions."
+	, syntax_doc_location = [CLR 5 "3.5.2" "_Toc311798004"]
+	, syntax_examples     = [EXs "Function" "macro" "primes = sieve [2..] // Local definitions\nwhere\n\tsieve [pr:r] = [pr:sieve (filter pr r)]"]
+	})
+
+bs_with = (["with"],
+	{ syntax_title        = "with"
+	, syntax_code         = ["with"]
+	, syntax_description  = "Introduces guard-local definitions."
+	, syntax_doc_location = [CLR 5 "3.5.3" "_Toc311798005"]
+	, syntax_examples     = [EXs "Function" "macro" "f x y\n| guard1 = alt1\n\twith local = expr1\n| guard2 = alt2\n\twith local = expr2"]
+	})

--- a/backend/Builtins.dcl
+++ b/backend/Builtins.dcl
@@ -1,7 +1,7 @@
 definition module Builtins
 
 from CloogleDB import :: Location, :: FunctionEntry, :: ClassEntry,
-	:: TypeDefEntry, :: SyntaxEntry, :: SyntaxResultExtras
+	:: TypeDefEntry, :: SyntaxEntry
 
 builtin_functions :: [(Location, FunctionEntry)]
 builtin_classes :: [(Location, ClassEntry)]

--- a/backend/Builtins.dcl
+++ b/backend/Builtins.dcl
@@ -1,0 +1,9 @@
+definition module Builtins
+
+from CloogleDB import :: Location, :: FunctionEntry, :: ClassEntry,
+	:: TypeDefEntry, :: SyntaxEntry, :: SyntaxResultExtras
+
+builtin_functions :: [(Location, FunctionEntry)]
+builtin_classes :: [(Location, ClassEntry)]
+builtin_types :: [(Location, TypeDefEntry)]
+builtin_syntax :: [([String], SyntaxEntry)]

--- a/backend/Builtins.icl
+++ b/backend/Builtins.icl
@@ -14,6 +14,7 @@ import Text
 import Type
 
 import Cloogle
+import Doc
 import CloogleDB
 
 builtin_functions :: [(Location, FunctionEntry)]
@@ -59,10 +60,46 @@ builtin_types
 	  , ( Builtin "File",    { deft & tde_typedef.td_name = "File"    } )
 	  , ( Builtin "World",   { deft & tde_typedef.td_name = "World",
 	      tde_typedef.td_uniq = True } )
+	  : lists
 	  ]
 where
 	deft = {tde_typedef={td_name="", td_uniq=False, td_args=[], td_rhs=TDRAbstract}, tde_doc=Nothing}
 	defc = {cons_name="", cons_args=[], cons_exi_vars=[], cons_context=[], cons_priority=Nothing}
+
+	lists = [make_list kind spine \\ kind <- [[], ['#'], ['!'], ['|']], spine <- [[], ['!']] | kind <> ['|'] || spine <> ['!']]
+	where
+		make_list :: [Char] [Char] -> (Location, TypeDefEntry)
+		make_list k s = (Builtin higherorder,
+			{ deft
+			& tde_typedef.td_name = toString (['_':k] ++ ['List'] ++ s)
+			, tde_typedef.td_args = [Var "a"]
+			, tde_doc             = Just $ TypeDoc (Just $ "A" + kind + spine + " list.\n\n" + description) ["The type of the list elements."] Nothing
+		//	, syntax_doc_locations = [CLR 6 "4.2" "_Toc311798019"]
+		//	, syntax_examples      = map (EXs "Function" "macro") ["f :: " <+ lista <+ " -> a", "ints = " <+ listints]
+			})
+		where
+			higherorder = toString (['[':k] ++ s` ++ [']'])
+				with s` = if (s == ['!'] && k == []) [' !'] s
+			lista       = toString (['[':k] ++ ['a':s] ++ [']'])
+			listints    = toString (['[':k] ++ ['1,1,2,3,5':s] ++ [']'])
+			listany     = toString (['[':k] ++ ['\\','w':s] ++ [']'])
+			kind = case k of
+				[]    ->  " normal"
+				['#'] -> "n unboxed"
+				['!'] ->  " head strict"
+				['|'] -> "n overloaded"
+			spine = case s of
+				[]    -> ""
+				['!'] -> " spine strict"
+
+			description = "These types of list are available:\n" +
+				"- {{`[a]`}}, a normal list\n" +
+				"- {{`[#a]`}}, an unboxed head-strict list (elements are stored directly, without pointers)\n" +
+				"- {{`[!a]`}}, a head-strict list (the first element is in root normal form)\n" +
+				"- {{`[a!]`}}, a spine-strict list (the last element is known)\n" +
+				"- {{`[#a!]`}}, an unboxed spine-strict list\n" +
+				"- {{`[!a!]`}}, a head-strict spine-strict list\n" +
+				"- {{`[|a]`}}, an overloaded list (one of the types above)"
 
 builtin_syntax :: [([String], SyntaxEntry)]
 builtin_syntax =
@@ -80,8 +117,7 @@ builtin_syntax =
 	, bs_instance
 	, bs_let
 	, bs_let_before
-	] ++ bs_lists ++
-	[ bs_macro
+	, bs_macro
 	, bs_module
 	, bs_otherwise
 	// TODO bs_selection (arrays and records)
@@ -98,8 +134,8 @@ builtin_syntax =
 	// TODO bs_zf
 	]
 
-CLR :: Int String String -> SyntaxDocLocation
-CLR f sec h = CleanLangReport
+CLR :: Int String String -> CleanLangReportLocation
+CLR f sec h =
 	{ clr_version = v
 	, clr_file    = "CleanRep." + v + "_" <+ f <+ ".htm"
 	, clr_section = sec
@@ -116,11 +152,11 @@ bs_arrays = [make_array kind \\ kind <- [[], ['!'], ['#']]]
 where
 	make_array :: [Char] -> ([SyntaxPattern], SyntaxEntry)
 	make_array k = (["array", typec, toString (['{':k]++['\\w}'])],
-		{ syntax_title        = kind + "array"
-		, syntax_code         = [typec]
-		, syntax_description  = "An array contains a finite number of elements of the same type. Access time is constant."
-		, syntax_doc_location = [CLR 6 "4.4" "_Toc311798029"]
-		, syntax_examples     = [EX "Function" ("xs :: {" <+ k <+ "Int}\nxs = {" <+ k <+ "1,3,6,10}")]
+		{ syntax_title         = kind + "array"
+		, syntax_code          = [typec]
+		, syntax_description   = "An array contains a finite number of elements of the same type. Access time is constant."
+		, syntax_doc_locations = [CLR 6 "4.4" "_Toc311798029"]
+		, syntax_examples      = [EX "Function" ("xs :: {" <+ k <+ "Int}\nxs = {" <+ k <+ "1,3,6,10}")]
 		})
 	where
 		typec = toString (['{':k]++['}'])
@@ -130,39 +166,39 @@ where
 			['#'] -> "unboxed "
 
 bs_case = (["case", "of", "case of"],
-	{ syntax_title        = "case expression"
-	, syntax_code         = ["case ... of ..."]
-	, syntax_description  = "Pattern match on an expression and do something depending on the alternative of the matching pattern."
-	, syntax_doc_location = [CLR 5 "3.4.2" "_Toc311798001"]
-	, syntax_examples     =
+	{ syntax_title         = "case expression"
+	, syntax_code          = ["case ... of ..."]
+	, syntax_description   = "Pattern match on an expression and do something depending on the alternative of the matching pattern."
+	, syntax_doc_locations = [CLR 5 "3.4.2" "_Toc311798001"]
+	, syntax_examples      =
 		[ EXs "Function" "macro" "isJust m = case m of\n\tJust _ -> True\n\t_      -> False"
 		]
 	})
 
 bs_class = (["class"],
-	{ syntax_title        = "class"
-	, syntax_code         =
+	{ syntax_title         = "class"
+	, syntax_code          =
 		[ "class ... ... :: ..."
 		, "class ... ... where ..."
 		]
-	, syntax_description  =
+	, syntax_description   =
 		"Classes are (sets of) overloaded functions. For classes with only one member function, a simplified syntax exists.\n" +
 		"Types can instantiate classes with the {{`instance`}} keyword."
-	, syntax_doc_location = [CLR 8 "6.1" "_Toc311798056"]
-	, syntax_examples     = map (EX "ClassDef")
+	, syntax_doc_locations = [CLR 8 "6.1" "_Toc311798056"]
+	, syntax_examples      = map (EX "ClassDef")
 		[ "class zero a :: a // one member" // TODO highlighting
 		, "class Text s      // multiple members\nwhere\n\ttextSize :: !s -> Int\n\tconcat :: ![s] -> s\n\t// ..." // TODO highlighting
 		]
 	})
 
 bs_code = (["code", "inline", "code inline"],
-	{ syntax_title        = "ABC code"
-	, syntax_code         = ["... = code [inline] { ... }"]
-	, syntax_description  =
+	{ syntax_title         = "ABC code"
+	, syntax_code          = ["... = code [inline] { ... }"]
+	, syntax_description   =
 		"A code block with raw ABC instructions, which can be used for primitive functions like integer addition, for linking with C, bypassing the type system... welcome down the rabbit hole!\n" +
 		"When `inline` is used, the function will be inlined when applied in a strict context."
-	, syntax_doc_location = [CLR 13 "11.2" "_Toc311798115"]
-	, syntax_examples     = map (EX "Function") // TODO highlighting
+	, syntax_doc_locations = [CLR 13 "11.2" "_Toc311798115"]
+	, syntax_examples      = map (EX "Function") // TODO highlighting
 		[ "add :: !Int !Int -> Int                   // Primitive function\nadd a b = code inline {\n\taddI\n}"
 		, "sleep :: !Int !*World -> *(!Int, !*World) // Linking with C\nsleep n w = code {\n\tccall sleep \"I:I:A\"\n}"
 		, "cast :: !.a -> .b                         // Bypassing the type system\ncast _ = code {\n\tpop_a 1\n}"
@@ -170,34 +206,34 @@ bs_code = (["code", "inline", "code inline"],
 	})
 
 bs_define_constant = (["=:"],
-	{ syntax_title        = "graph definition"
-	, syntax_code         = ["... =: ..."]
-	, syntax_description  =
+	{ syntax_title         = "graph definition"
+	, syntax_code          = ["... =: ..."]
+	, syntax_description   =
 		"Defining constants with `=:` at the top level makes sure they are shared through out the program; hence, they are evaluated only once.\n" +
 		"This is the default understanding of `=` in local scope.\n" +
 		"The inverse is {{`=>`}}, which defines an identifier to be a constant function."
-	, syntax_doc_location = [CLR 5 "3.6" "_Toc311798007"]
-	, syntax_examples     = [EXs "Function" "macro" "mylist =: [1..10000]"]
+	, syntax_doc_locations = [CLR 5 "3.6" "_Toc311798007"]
+	, syntax_examples      = [EXs "Function" "macro" "mylist =: [1..10000]"]
 	})
 bs_define_graph = (["=>"],
-	{ syntax_title        = "constant function definition"
-	, syntax_code         = ["... => ..."]
-	, syntax_description  =
+	{ syntax_title         = "constant function definition"
+	, syntax_code          = ["... => ..."]
+	, syntax_description   =
 		"Defining constants with `=>` at the top level makes sure they are interpreted as constant functions; hence, they are evaluated every time they are needed.\n" +
 		"This is the default understanding of `=` in global scope.\n" +
 		"The inverse is {{`=:`}}, which defines an identifier to be a graph."
-	, syntax_doc_location = [CLR 5 "3.6" "_Toc311798007"]
-	, syntax_examples     = [EXs "Function" "macro" "mylist => [1..10000]"]
+	, syntax_doc_locations = [CLR 5 "3.6" "_Toc311798007"]
+	, syntax_examples      = [EXs "Function" "macro" "mylist => [1..10000]"]
 	})
 
 bs_dotdot = (["[\\e..]", "[\\e..\e]", "[\\e,\\e..]", "[[\\e,\\e..\\e]", "dotdot", "dot-dot"],
-	{ syntax_title        = "dotdot expression"
-	, syntax_code         = ["[i..]", "[i..k]", "[i,j..]", "[i,j..k]"]
-	, syntax_description  =
+	{ syntax_title         = "dotdot expression"
+	, syntax_code          = ["[i..]", "[i..k]", "[i,j..]", "[i,j..k]"]
+	, syntax_description   =
 		"A shorthand for lists of enumerable types.\n" +
 		"To use these expressions, you must import {{`StdEnum`}}. The underlying functions are defined in {{`_SystemEnum`}}."
-	, syntax_doc_location = [CLR 6 "4.2.1" "_Toc311798023"]
-	, syntax_examples     = map (EXs "Function" "macro")
+	, syntax_doc_locations = [CLR 6 "4.2.1" "_Toc311798023"]
+	, syntax_examples      = map (EXs "Function" "macro")
 		[ "xs = [0..]     // 0, 1, 2, 3, ..."
 		, "xs = [0,2..]   // 0, 2, 4, 6, ..."
 		, "xs = [0..10]   // 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10"
@@ -206,33 +242,33 @@ bs_dotdot = (["[\\e..]", "[\\e..\e]", "[\\e,\\e..]", "[[\\e,\\e..\\e]", "dotdot"
 	})
 
 bs_exists = (["E", "E.*"],
-	{ syntax_title        = "existential quantifier"
-	, syntax_code         = [":: ... = E. ...: ..."]
-	, syntax_description  = "Existential quantifiers make it possible to define (recursive) objects of the same type with different types of content."
-	, syntax_doc_location = [CLR 7 "5.1.3" "_Toc311798042"]
-	, syntax_examples     = [EX "Function" ":: List = E.e: Cons e List | Nil\nStart = Cons 5 (Cons 'a' (Cons \"abc\" Nil))"] // TODO highlighting
+	{ syntax_title         = "existential quantifier"
+	, syntax_code          = [":: ... = E. ...: ..."]
+	, syntax_description   = "Existential quantifiers make it possible to define (recursive) objects of the same type with different types of content."
+	, syntax_doc_locations = [CLR 7 "5.1.3" "_Toc311798042"]
+	, syntax_examples      = [EX "Function" ":: List = E.e: Cons e List | Nil\nStart = Cons 5 (Cons 'a' (Cons \"abc\" Nil))"] // TODO highlighting
 	})
 
 bs_forall = (["A", "A.*"],
-	{ syntax_title        = "universal quantifier"
-	, syntax_code         = ["A. ...:"]
-	, syntax_description  = "Explicitly marks polymorphic type variables. Clean does not yet allow universal quantifiers on the topmost level."
-	, syntax_doc_location = [CLR 5 "3.7.4" "_Toc311798013"]
-	, syntax_examples     = map (EX "Function")
+	{ syntax_title         = "universal quantifier"
+	, syntax_code          = ["A. ...:"]
+	, syntax_description   = "Explicitly marks polymorphic type variables. Clean does not yet allow universal quantifiers on the topmost level."
+	, syntax_doc_locations = [CLR 5 "3.7.4" "_Toc311798013"]
+	, syntax_examples      = map (EX "Function")
 		[ "hd :: A.a: [a] -> a           // Not yet allowed: A. on the topmost level"
 		, "h :: (A.a: [a] -> Int) -> Int // The quantifier is needed to apply the function to both a [Int] and a [Char]\nh f = f [1..100] + f ['a'..'z']"
 		]
 	})
 
 bs_import = (["import", "from", "qualified", "as"],
-	{ syntax_title        = "imports"
-	, syntax_code         = ["import [qualified] ... [as ...]", "from ... import ..."]
-	, syntax_description  =
+	{ syntax_title         = "imports"
+	, syntax_code          = ["import [qualified] ... [as ...]", "from ... import ..."]
+	, syntax_description   =
 		"Imports code from other modules.\n" +
 		"With the `from` keyword, one can achieve more granularity.\n" +
 		"In case of name clashes, `qualified` can be used (undocumented)."
-	, syntax_doc_location = [CLR 4 "2.5" "_Toc311797991"]
-	, syntax_examples     = map (EX "Function")
+	, syntax_doc_locations = [CLR 4 "2.5" "_Toc311797991"]
+	, syntax_examples      = map (EX "Function")
 		[ "import ..."
 		, "import StdEnv                  // Import all code from the StdEnv definition module"
 		, "from StdFunc import o          // Import only the o function from StdFunc"
@@ -241,14 +277,14 @@ bs_import = (["import", "from", "qualified", "as"],
 	})
 
 bs_infix = (["infix", "infixl", "infixr"],
-	{ syntax_title        = "infix operator"
-	, syntax_code         = ["infix[l,r] [...]"]
-	, syntax_description  =
+	{ syntax_title         = "infix operator"
+	, syntax_code          = ["infix[l,r] [...]"]
+	, syntax_description   =
 		"Defines a function with arity 2 that can be used in infix position.\n" +
 		"The following number, if any, determines the precedence.\n" +
 		"`infixl` and `infixr` indicate associativity."
-	, syntax_doc_location = [CLR 5 "3.7.2" "_Toc311798011"]
-	, syntax_examples     =
+	, syntax_doc_locations = [CLR 5 "3.7.2" "_Toc311798011"]
+	, syntax_examples      =
 		[ EX  "Function"         "(bitor) infixl 6 :: !Int !Int -> Int // Left-associative infix function with precedence 6"
 		, EXs "Function" "macro" "(o) infixr 9                         // Infix macro\n(o) f g :== \\x -> f (g x)"
 		, EX  "TypeDef"          ":: MyType = (:+:) infixl 6 Int Int   // Infix data constructor, can be used as (5 :+: 10)"
@@ -256,78 +292,44 @@ bs_infix = (["infix", "infixl", "infixr"],
 	})
 
 bs_instance = (["instance"],
-	{ syntax_title        = "instance"
-	, syntax_code         = ["instance ... ... where ..."]
-	, syntax_description  = "Defines an instantiation of a {{class}} for a type."
-	, syntax_doc_location = [CLR 8 "6.1" "_Toc311798056"]
-	, syntax_examples     = map (EX "Function")
+	{ syntax_title         = "instance"
+	, syntax_code          = ["instance ... ... where ..."]
+	, syntax_description   = "Defines an instantiation of a {{class}} for a type."
+	, syntax_doc_locations = [CLR 8 "6.1" "_Toc311798056"]
+	, syntax_examples      = map (EX "Function")
 		[ "instance zero Int\nwhere\n\tzero = 0"
 		, "instance zero Real\nwhere\n\tzero = 0.0"
 		]
 	})
 
 bs_let = (["let", "in", "let in"],
-	{ syntax_title        = "let expression"
-	, syntax_code         = ["let ... in ..."]
-	, syntax_description  = "An expression that introduces new scope."
-	, syntax_doc_location = [CLR 5 "3.5.1" "_Toc311798003"]
-	, syntax_examples     =
+	{ syntax_title         = "let expression"
+	, syntax_code          = ["let ... in ..."]
+	, syntax_description   = "An expression that introduces new scope."
+	, syntax_doc_locations = [CLR 5 "3.5.1" "_Toc311798003"]
+	, syntax_examples      =
 		[ EXs "Function" "macro"    "fac n = let fs = [1:1:[(fs!!(i-1)) + (fs!!(i-2)) \\ i <- [2..]]] in fs !! n"
 		, EXs "Function" "macrorhs" "let // Multi-line let expressions\n\tfunction args = body\n\tselector = expr\n\t// ...\nin expression"
 		]
 	})
 bs_let_before = (["#", "#!"],
-	{ syntax_title        = "let before"
-	, syntax_code         = ["#  ... = ...", "#! ... = ..."]
-	, syntax_description  = "A {{`let`}} expression that can be defined before a guard or function body, which eases the syntax of sequential actions."
-	, syntax_doc_location = [CLR 5 "3.5.4" "_Toc311798006"]
-	, syntax_examples     =
+	{ syntax_title         = "let before"
+	, syntax_code          = ["#  ... = ...", "#! ... = ..."]
+	, syntax_description   = "A {{`let`}} expression that can be defined before a guard or function body, which eases the syntax of sequential actions."
+	, syntax_doc_locations = [CLR 5 "3.5.4" "_Toc311798006"]
+	, syntax_examples      =
 		[ EX "Function" "readchars :: *File -> *([Char], *File)\nreadchars f\n# (ok,c,f) = freadc file\n| not ok   = ([], f)\n# (cs,f)   = readchars f\n= ([c:cs], f)"
 		]
 	})
 
-bs_lists = [make_list kind spine \\ kind <- [[], ['#'], ['!'], ['|']], spine <- [[], ['!']] | kind <> ['|'] || spine <> ['!']]
-where
-	make_list :: [Char] [Char] -> ([SyntaxPattern], SyntaxEntry)
-	make_list k s = ([higherorder, listany, "list"],
-		{ syntax_title        = "lists"
-		, syntax_code         = [higherorder]
-		, syntax_description  = "A" + kind + spine + " list.\n\n" + description
-		, syntax_doc_location = [CLR 6 "4.2" "_Toc311798019"]
-		, syntax_examples     = map (EXs "Function" "macro") ["f :: " <+ lista <+ " -> a", "ints = " <+ listints]
-		})
-	where
-		higherorder = toString (['[':k] ++ s` ++ [']'])
-			with s` = if (s == ['!'] && k == []) [' !'] s
-		lista       = toString (['[':k] ++ ['a':s] ++ [']'])
-		listints    = toString (['[':k] ++ ['1,1,2,3,5':s] ++ [']'])
-		listany     = toString (['[':k] ++ ['\\','w':s] ++ [']'])
-		kind = case k of
-			[]    ->  " normal"
-			['#'] -> "n unboxed"
-			['!'] ->  " head strict"
-			['|'] -> "n overloaded"
-		spine = case s of
-			[]    -> ""
-			['!'] -> " spine strict"
-
-		description = "These types of list are available:\n" +
-			"- {{`[a]`}}, a normal list\n" +
-			"- {{`[#a]`}}, an unboxed head-strict list (elements are stored directly, without pointers)\n" +
-			"- {{`[!a]`}}, a head-strict list (the first element is in root normal form)\n" +
-			"- {{`[a!]`}}, a spine-strict list (the last element is known)\n" +
-			"- {{`[#a!]`}}, an unboxed spine-strict list\n" +
-			"- {{`[!a!]`}}, a head-strict spine-strict list\n" +
-			"- {{`[|a]`}}, an overloaded list (one of the types above)"
-
 bs_macro = ([":==", "macro"],
-	{ syntax_title        = "macro"
-	, syntax_code         = ["... :== ..."]
-	, syntax_description  =
+	{ syntax_title         = "macro"
+	, syntax_code          = ["... :== ..."]
+	, syntax_description   =
 		"A macro is a compile-time rewrite rule. It can be used for constants, inline subtitutions, renaming functions, conditional compilation, etc.\n" +
 		"Macros can appear in patterns to match on constants."
-	, syntax_doc_location = [CLR 12 "10.3" "_Toc311798111"]
-	, syntax_examples     = map (EXs "Function" "macro")
+	, syntax_doc_locations = [CLR 12 "10.3" "_Toc311798111"]
+	, syntax_examples      = map (EXs "Function" "macro")
 		[ "flip f a b :== f b a                    // Useful for currying"
 		, "IF_INT_64_OR_32 int64 int32 :== int64   // Conditional compilation"
 		, "(o) infixr 9                            // Function composition. Doing this at run-time would be slow\n(o) f g :== \\x -> f (g x)"
@@ -335,11 +337,11 @@ bs_macro = ([":==", "macro"],
 	})
 
 bs_module = (["module", "definition", "implementation", "system", "definition module", "implementation module", "system module"],
-	{ syntax_title        = "module heading"
-	, syntax_code         = ["[definition,implementation,system] module ..."]
-	, syntax_description  = "The heading of a Clean file. Definition modules describe what things are exported (dcl files), implementation modules how they are implemented (icl files)."
-	, syntax_doc_location = [CLR 4 "2.2" "_Toc311797983"]
-	, syntax_examples     = map (EX "Function")
+	{ syntax_title         = "module heading"
+	, syntax_code          = ["[definition,implementation,system] module ..."]
+	, syntax_description   = "The heading of a Clean file. Definition modules describe what things are exported (dcl files), implementation modules how they are implemented (icl files)."
+	, syntax_doc_locations = [CLR 4 "2.2" "_Toc311797983"]
+	, syntax_examples      = map (EX "Function")
 		[ "definition module ..."
 		, "definition module StdList     // Exported definitions of list functions"
 		, "implementation module StdList // The implementations of the functions"
@@ -349,50 +351,50 @@ bs_module = (["module", "definition", "implementation", "system", "definition mo
 	})
 
 bs_otherwise = (["otherwise"],
-	{ syntax_title        = "otherwise"
-	, syntax_code         = ["otherwise"]
-	, syntax_description  = "The (optional) last alternative in a guard. It caches all other cases, and makes sure your program does not crash if none of the cases matches."
-	, syntax_doc_location = [CLR 5 "3.3" "_Toc311797998"]
-	, syntax_examples     =
+	{ syntax_title         = "otherwise"
+	, syntax_code          = ["otherwise"]
+	, syntax_description   = "The (optional) last alternative in a guard. It caches all other cases, and makes sure your program does not crash if none of the cases matches."
+	, syntax_doc_locations = [CLR 5 "3.3" "_Toc311797998"]
+	, syntax_examples      =
 		[ EXs "Function" "macrorhs" "| otherwise = ..."
 		, EXs "Function" "macro"    "sign :: !Int -> Int\nsign n\n| n  < 0    = -1 // Negative number\n| n == 0    =  0 // Zero\n| otherwise =  1 // Must be positive"
 		]
 	})
 
 bs_strict = (["strict", "!"],
-	{ syntax_title        = "strictness annotation"
-	, syntax_code         = ["!"]
-	, syntax_description  = "Override the lazy evaluation strategy: the argument must be evaluated to head normal form before the function is entered."
-	, syntax_doc_location = [CLR 5 "3.7.5" "_Toc311798014", CLR 12 "10" "_Toc311798103"]
-	, syntax_examples     = [EX "Function" "acker :: !Int !Int -> Int"]
+	{ syntax_title         = "strictness annotation"
+	, syntax_code          = ["!"]
+	, syntax_description   = "Override the lazy evaluation strategy: the argument must be evaluated to head normal form before the function is entered."
+	, syntax_doc_locations = [CLR 5 "3.7.5" "_Toc311798014", CLR 12 "10" "_Toc311798103"]
+	, syntax_examples      = [EX "Function" "acker :: !Int !Int -> Int"]
 	})
 
 bs_synonym = (["synonym", ":=="],
-	{ syntax_title        = "synonym type definition"
-	, syntax_code         = [":: ... :== ..."]
-	, syntax_description  = "Defines a new type name for an existing type."
-	, syntax_doc_location = [CLR 7 "5.3" "_Toc311798052"]
-	, syntax_examples     = [EX "TypeDef" ":: String :== {#Char}"]
+	{ syntax_title         = "synonym type definition"
+	, syntax_code          = [":: ... :== ..."]
+	, syntax_description   = "Defines a new type name for an existing type."
+	, syntax_doc_locations = [CLR 7 "5.3" "_Toc311798052"]
+	, syntax_examples      = [EX "TypeDef" ":: String :== {#Char}"]
 	})
 bs_synonym_abstract = (["synonym", ":=="],
-	{ syntax_title        = "abstract synonym type definition"
-	, syntax_code         = [":: ... (:== ...)"]
-	, syntax_description  = "Defines a new type name for an existing type, while the type behaves as an abstract type for the programmer. This allows compiler optimisations on abstract types."
-	, syntax_doc_location = [CLR 7 "5.4.1" "_Toc311798054"]
-	, syntax_examples     = [EX "TypeDef" ":: Stack a (:== [a])"]
+	{ syntax_title         = "abstract synonym type definition"
+	, syntax_code          = [":: ... (:== ...)"]
+	, syntax_description   = "Defines a new type name for an existing type, while the type behaves as an abstract type for the programmer. This allows compiler optimisations on abstract types."
+	, syntax_doc_locations = [CLR 7 "5.4.1" "_Toc311798054"]
+	, syntax_examples      = [EX "TypeDef" ":: Stack a (:== [a])"]
 	})
 
 bs_tuples = [make_tuple n \\ n <- [1..31]]
 where
 	make_tuple :: Int -> ([SyntaxPattern], SyntaxEntry)
 	make_tuple n = ([toString ['(':repeatn n ','++[')']], withargs, "tuple"],
-		{ syntax_title        = ary + "ary tuple"
-		, syntax_code         = [withvars]
-		, syntax_description  =
+		{ syntax_title         = ary + "ary tuple"
+		, syntax_code          = [withvars]
+		, syntax_description   =
 			"Tuples allow bundling a finite number of expressions of different types into one object without defining a new data type.\n" +
 			"Clean supports tuples of arity 2 to 32."
-		, syntax_doc_location = [CLR 6 "4.3" "_Toc311798026"]
-		, syntax_examples     = []
+		, syntax_doc_locations = [CLR 6 "4.3" "_Toc311798026"]
+		, syntax_examples      = []
 		})
 	where
 		withargs = toString ['(\\w':foldl (++) [] [[',\\w'] \\ _ <- [1..n]] ++ [')']]
@@ -403,46 +405,46 @@ where
 			n -> n+1 <+ "-"
 
 bs_update_array = (["&", "{*&*[\\e]*=*}"],
-	{ syntax_title        = "array update"
-	, syntax_code         = ["{ a & [i]=x, [j]=y, ... } // Updates a by setting index i to x, j to y, ..."]
-	, syntax_description  = "Updates an array by creating a copy and replacing one or more elements"
-	, syntax_doc_location = [CLR 6 "4.4.1" "_Toc311798032"]
-	, syntax_examples     = []
+	{ syntax_title         = "array update"
+	, syntax_code          = ["{ a & [i]=x, [j]=y, ... } // Updates a by setting index i to x, j to y, ..."]
+	, syntax_description   = "Updates an array by creating a copy and replacing one or more elements"
+	, syntax_doc_locations = [CLR 6 "4.4.1" "_Toc311798032"]
+	, syntax_examples      = []
 	})
 bs_update_record = (["&", "{*&*=*}"],
-	{ syntax_title        = "record update"
-	, syntax_code         = ["{ r & f1=x, f2=y, ... } // Updates r by setting f1 to x, f2 to y, ..."]
-	, syntax_description  = "Updates a record by creating a copy and replacing one or more fields"
-	, syntax_doc_location = [CLR 7 "5.2.1" "_Toc311798049"]
-	, syntax_examples     = []
+	{ syntax_title         = "record update"
+	, syntax_code          = ["{ r & f1=x, f2=y, ... } // Updates r by setting f1 to x, f2 to y, ..."]
+	, syntax_description   = "Updates a record by creating a copy and replacing one or more fields"
+	, syntax_doc_locations = [CLR 7 "5.2.1" "_Toc311798049"]
+	, syntax_examples      = []
 	})
 
 bs_where_class = (["where"],
-	{ syntax_title        = "where"
-	, syntax_code         = ["where"]
-	, syntax_description  = "Introduces the members of a {{`class`}} definition."
-	, syntax_doc_location = [CLR 8 "6.1"   "_Toc311798056"]
-	, syntax_examples     = [EX "ClassDef" "class Arith a        // Class definition\nwhere\n\t(+) infixl 6 :: a a -> a\n\t(-) infixl 6 :: a a -> a"] // TODO highlighting
+	{ syntax_title         = "where"
+	, syntax_code          = ["where"]
+	, syntax_description   = "Introduces the members of a {{`class`}} definition."
+	, syntax_doc_locations = [CLR 8 "6.1"   "_Toc311798056"]
+	, syntax_examples      = [EX "ClassDef" "class Arith a        // Class definition\nwhere\n\t(+) infixl 6 :: a a -> a\n\t(-) infixl 6 :: a a -> a"] // TODO highlighting
 	})
 bs_where_instance = (["where"],
-	{ syntax_title        = "where"
-	, syntax_code         = ["where"]
-	, syntax_description  = "Introduces the implementation of an {{`instance`}}."
-	, syntax_doc_location = [CLR 8 "6.1"   "_Toc311798056"]
-	, syntax_examples     = [EX "Function" "instance Arith Int   // Instance definition\nwhere\n\t(+) x y = // ...\n\t(-) x y = // ..."]
+	{ syntax_title         = "where"
+	, syntax_code          = ["where"]
+	, syntax_description   = "Introduces the implementation of an {{`instance`}}."
+	, syntax_doc_locations = [CLR 8 "6.1"   "_Toc311798056"]
+	, syntax_examples      = [EX "Function" "instance Arith Int   // Instance definition\nwhere\n\t(+) x y = // ...\n\t(-) x y = // ..."]
 	})
 bs_where_local = (["where"],
-	{ syntax_title        = "where"
-	, syntax_code         = ["where"]
-	, syntax_description  = "Introduces local definitions. For guard-local definitions, see {{`with`}}."
-	, syntax_doc_location = [CLR 5 "3.5.2" "_Toc311798004"]
-	, syntax_examples     = [EXs "Function" "macro" "primes = sieve [2..] // Local definitions\nwhere\n\tsieve [pr:r] = [pr:sieve (filter pr r)]"]
+	{ syntax_title         = "where"
+	, syntax_code          = ["where"]
+	, syntax_description   = "Introduces local definitions. For guard-local definitions, see {{`with`}}."
+	, syntax_doc_locations = [CLR 5 "3.5.2" "_Toc311798004"]
+	, syntax_examples      = [EXs "Function" "macro" "primes = sieve [2..] // Local definitions\nwhere\n\tsieve [pr:r] = [pr:sieve (filter pr r)]"]
 	})
 
 bs_with = (["with"],
-	{ syntax_title        = "with"
-	, syntax_code         = ["with"]
-	, syntax_description  = "Introduces guard-local definitions. For function-local definitions, see {{`where`}}."
-	, syntax_doc_location = [CLR 5 "3.5.3" "_Toc311798005"]
-	, syntax_examples     = [EXs "Function" "macro" "f x y\n| guard1 = alt1\n\twith local = expr1\n| guard2 = alt2\n\twith local = expr2"]
+	{ syntax_title         = "with"
+	, syntax_code          = ["with"]
+	, syntax_description   = "Introduces guard-local definitions. For function-local definitions, see {{`where`}}."
+	, syntax_doc_locations = [CLR 5 "3.5.3" "_Toc311798005"]
+	, syntax_examples      = [EXs "Function" "macro" "f x y\n| guard1 = alt1\n\twith local = expr1\n| guard2 = alt2\n\twith local = expr2"]
 	})

--- a/backend/Builtins.icl
+++ b/backend/Builtins.icl
@@ -1,4 +1,4 @@
-implementation module BuiltinSyntax
+implementation module Builtins
 
 import StdBool
 import StdEnum
@@ -7,11 +7,62 @@ import StdList
 import StdOverloaded
 import StdString
 
+from Data.Func import $
 import Data.Maybe
 import Text
 
+import Type
+
 import Cloogle
 import CloogleDB
+
+builtin_functions :: [(Location, FunctionEntry)]
+builtin_functions
+	= [ ( Builtin "if"
+	    , {zero & fe_type=Just $ Func [Type "Bool" [], Var "a", Var "a"] (Var "a") []}
+	    )
+	  , ( Builtin "dynamic"
+	    , {zero & fe_type=Just $ Func [Var "a"] (Type "Dynamic" []) [Instance "TC" [Var "a"]]}
+	    )
+	  ]
+
+builtin_classes :: [(Location, ClassEntry)]
+builtin_classes
+	= [ ( Builtin "TC"
+	    , { ce_vars=["v"]
+	      , ce_context=[]
+	      , ce_documentation=Nothing
+	      , ce_members=[]
+	      , ce_instances=[]
+	      , ce_derivations=[]
+	      }
+	    )
+	  ]
+
+builtin_types :: [(Location, TypeDefEntry)]
+builtin_types
+	= [ ( Builtin "Bool"
+	    , { deft
+	      & tde_typedef.td_name = "Bool"
+	      , tde_typedef.td_rhs  = TDRCons False
+	        [ { defc & cons_name="False" }
+	        , { defc & cons_name="True" }
+	        ]
+	      }
+	    )
+	  , ( Builtin "Int",     { deft & tde_typedef.td_name = "Int"     } )
+	  , ( Builtin "Real",    { deft & tde_typedef.td_name = "Real"    } )
+	  , ( Builtin "Char",    { deft & tde_typedef.td_name = "Char"    } )
+	  , ( Builtin "String",  { deft & tde_typedef.td_name = "String",
+	      tde_typedef.td_rhs = TDRSynonym (Type "_#Array" [Type "Char" []]) } )
+	  , ( Builtin "Dynamic", { deft & tde_typedef.td_name = "Dynamic" } )
+	  , ( Builtin "File",    { deft & tde_typedef.td_name = "File"    } )
+	  , ( Builtin "World",   { deft & tde_typedef.td_name = "World",
+	      tde_typedef.td_uniq = True } )
+	  ]
+where
+	deft = {tde_typedef={td_name="", td_uniq=False, td_args=[], td_rhs=TDRAbstract}, tde_doc=Nothing}
+	defc = {cons_name="", cons_args=[], cons_exi_vars=[], cons_context=[], cons_priority=Nothing}
 
 builtin_syntax :: [([String], SyntaxEntry)]
 builtin_syntax =

--- a/backend/Builtins.icl
+++ b/backend/Builtins.icl
@@ -19,17 +19,17 @@ import CloogleDB
 
 builtin_functions :: [(Location, FunctionEntry)]
 builtin_functions
-	= [ ( Builtin "if"
+	= [ ( Builtin "if" [CLR 5 "3.4.2" "_Toc311798001"]
 	    , {zero & fe_type=Just $ Func [Type "Bool" [], Var "a", Var "a"] (Var "a") []}
 	    )
-	  , ( Builtin "dynamic"
+	  , ( Builtin "dynamic" [CLR 10 "8.1" "_Toc311798076"]
 	    , {zero & fe_type=Just $ Func [Var "a"] (Type "Dynamic" []) [Instance "TC" [Var "a"]]}
 	    )
 	  ]
 
 builtin_classes :: [(Location, ClassEntry)]
 builtin_classes
-	= [ ( Builtin "TC"
+	= [ ( Builtin "TC" [CLR 10 "8.1.4" "_Toc311798080"]
 	    , { ce_vars=["v"]
 	      , ce_context=[]
 	      , ce_documentation=Nothing
@@ -42,7 +42,7 @@ builtin_classes
 
 builtin_types :: [(Location, TypeDefEntry)]
 builtin_types
-	= [ ( Builtin "Bool"
+	= [ ( Builtin "Bool" [CLR 6 "4.1" "_Toc311798017"]
 	    , { deft
 	      & tde_typedef.td_name = "Bool"
 	      , tde_typedef.td_rhs  = TDRCons False
@@ -51,14 +51,14 @@ builtin_types
 	        ]
 	      }
 	    )
-	  , ( Builtin "Int",     { deft & tde_typedef.td_name = "Int"     } )
-	  , ( Builtin "Real",    { deft & tde_typedef.td_name = "Real"    } )
-	  , ( Builtin "Char",    { deft & tde_typedef.td_name = "Char"    } )
-	  , ( Builtin "String",  { deft & tde_typedef.td_name = "String",
+	  , ( Builtin "Int"     [CLR 6 "4.1" "_Toc311798017"], {deft & tde_typedef.td_name = "Int"})
+	  , ( Builtin "Real"    [CLR 6 "4.1" "_Toc311798017"], {deft & tde_typedef.td_name = "Real"})
+	  , ( Builtin "Char"    [CLR 6 "4.1" "_Toc311798017"], {deft & tde_typedef.td_name = "Char"})
+	  , ( Builtin "String"  [CLR 6 "4.7" "_Toc311798037"], {deft & tde_typedef.td_name = "String",
 	      tde_typedef.td_rhs = TDRSynonym (Type "_#Array" [Type "Char" []]) } )
-	  , ( Builtin "Dynamic", { deft & tde_typedef.td_name = "Dynamic" } )
-	  , ( Builtin "File",    { deft & tde_typedef.td_name = "File"    } )
-	  , ( Builtin "World",   { deft & tde_typedef.td_name = "World",
+	  , ( Builtin "Dynamic" [CLR 10 "8"  "_Toc311798077"], {deft & tde_typedef.td_name = "Dynamic"})
+	  , ( Builtin "File"    [CLR 6 "4.7" "_Toc311798037"], {deft & tde_typedef.td_name = "File"})
+	  , ( Builtin "World"   [CLR 6 "4.7" "_Toc311798037"], {deft & tde_typedef.td_name = "World",
 	      tde_typedef.td_uniq = True } )
 	  : lists
 	  ]
@@ -69,13 +69,11 @@ where
 	lists = [make_list kind spine \\ kind <- [[], ['#'], ['!'], ['|']], spine <- [[], ['!']] | kind <> ['|'] || spine <> ['!']]
 	where
 		make_list :: [Char] [Char] -> (Location, TypeDefEntry)
-		make_list k s = (Builtin higherorder,
+		make_list k s = (Builtin higherorder [CLR 6 "4.2" "_Toc311798019"],
 			{ deft
 			& tde_typedef.td_name = toString (['_':k] ++ ['List'] ++ s)
 			, tde_typedef.td_args = [Var "a"]
 			, tde_doc             = Just $ TypeDoc (Just $ "A" + kind + spine + " list.\n\n" + description) ["The type of the list elements."] Nothing
-		//	, syntax_doc_locations = [CLR 6 "4.2" "_Toc311798019"]
-		//	, syntax_examples      = map (EXs "Function" "macro") ["f :: " <+ lista <+ " -> a", "ints = " <+ listints]
 			})
 		where
 			higherorder = toString (['[':k] ++ s` ++ [']'])

--- a/backend/builddb.icl
+++ b/backend/builddb.icl
@@ -21,7 +21,7 @@ import Type
 from CloogleDBFactory import :: TemporaryDB, newTemporaryDb, finaliseDb,
 	findModules, indexModule, constructor_functions, record_functions
 
-import BuiltinSyntax
+import Builtins
 
 :: CLI = { help    :: Bool
          , version :: Bool
@@ -91,13 +91,13 @@ Start w
 	# mods        = flatten modss
 	#! (db, w)    = loop cli.root mods newTemporaryDb w
 	#! db         = finaliseDb db newDb
-	#! db         = putFunctions predefFunctions db
-	#! db         = putClasses predefClasses db
-	#! db         = putTypes predefTypes db
-	#! db         = putFunctions (flatten $ map constructor_functions predefTypes) db
-	#! db         = putFunctions (flatten $ map record_functions predefTypes) db
-	#! db         = syncDb 2 db
+	#! db         = putFunctions builtin_functions db
+	#! db         = putClasses builtin_classes db
+	#! db         = putTypes builtin_types db
+	#! db         = putFunctions (flatten $ map constructor_functions builtin_types) db
+	#! db         = putFunctions (flatten $ map record_functions builtin_types) db
 	#! db         = putSyntaxElems builtin_syntax db
+	#! db         = syncDb 2 db
 	#! (ok1,w)    = fclose (printStats db stderr) w
 	#! f          = saveDb db f
 	#! (ok2,w)    = fclose f w
@@ -153,51 +153,3 @@ where
 				, syntaxCount db
 				]
 		pad n i = {' ' \\ _ <- [0..n-size (toString i)-1]} +++ toString i
-
-predefFunctions :: [(Location, FunctionEntry)]
-predefFunctions
-	= [ ( Builtin "if"
-	    , {zero & fe_type=Just $ Func [Type "Bool" [], Var "a", Var "a"] (Var "a") []}
-	    )
-	  , ( Builtin "dynamic"
-	    , {zero & fe_type=Just $ Func [Var "a"] (Type "Dynamic" []) [Instance "TC" [Var "a"]]}
-	    )
-	  ]
-
-predefClasses :: [(Location, ClassEntry)]
-predefClasses
-	= [ ( Builtin "TC"
-	    , { ce_vars=["v"]
-	      , ce_context=[]
-	      , ce_documentation=Nothing
-	      , ce_members=[]
-	      , ce_instances=[]
-	      , ce_derivations=[]
-	      }
-	    )
-	  ]
-
-predefTypes :: [(Location, TypeDefEntry)]
-predefTypes
-	= [ ( Builtin "Bool"
-	    , { deft
-	      & tde_typedef.td_name = "Bool"
-	      , tde_typedef.td_rhs  = TDRCons False
-	        [ { defc & cons_name="False" }
-	        , { defc & cons_name="True" }
-	        ]
-	      }
-	    )
-	  , ( Builtin "Int",     { deft & tde_typedef.td_name = "Int"     } )
-	  , ( Builtin "Real",    { deft & tde_typedef.td_name = "Real"    } )
-	  , ( Builtin "Char",    { deft & tde_typedef.td_name = "Char"    } )
-	  , ( Builtin "String",  { deft & tde_typedef.td_name = "String",
-	      tde_typedef.td_rhs = TDRSynonym (Type "_#Array" [Type "Char" []]) } )
-	  , ( Builtin "Dynamic", { deft & tde_typedef.td_name = "Dynamic" } )
-	  , ( Builtin "File",    { deft & tde_typedef.td_name = "File"    } )
-	  , ( Builtin "World",   { deft & tde_typedef.td_name = "World",
-	      tde_typedef.td_uniq = True } )
-	  ]
-where
-	deft = {tde_typedef={td_name="", td_uniq=False, td_args=[], td_rhs=TDRAbstract}, tde_doc=Nothing}
-	defc = {cons_name="", cons_args=[], cons_exi_vars=[], cons_context=[], cons_priority=Nothing}

--- a/backend/builddb.icl
+++ b/backend/builddb.icl
@@ -21,6 +21,8 @@ import Type
 from CloogleDBFactory import :: TemporaryDB, newTemporaryDb, finaliseDb,
 	findModules, indexModule, constructor_functions, record_functions
 
+import BuiltinSyntax
+
 :: CLI = { help    :: Bool
          , version :: Bool
          , root    :: String
@@ -95,6 +97,7 @@ Start w
 	#! db         = putFunctions (flatten $ map constructor_functions predefTypes) db
 	#! db         = putFunctions (flatten $ map record_functions predefTypes) db
 	#! db         = syncDb 2 db
+	#! db         = putSyntaxElems builtin_syntax db
 	#! (ok1,w)    = fclose (printStats db stderr) w
 	#! f          = saveDb db f
 	#! (ok2,w)    = fclose f w
@@ -131,21 +134,23 @@ where
 
 	printStats :: !CloogleDB !*File -> *File
 	printStats db f = f
-		<<< "+-------------+-------+\n"
-		<<< "| Modules     | " <<< modules <<< " |\n"
-		<<< "| Functions   | " <<< funs    <<< " |\n"
-		<<< "| Types       | " <<< types   <<< " |\n"
-		<<< "| Classes     | " <<< classes <<< " |\n"
-		<<< "| Derivations | " <<< derives <<< " |\n"
-		<<< "+-------------+-------+\n"
+		<<< "+-------------------+-------+\n"
+		<<< "| Modules           | " <<< modules <<< " |\n"
+		<<< "| Functions         | " <<< funs    <<< " |\n"
+		<<< "| Types             | " <<< types   <<< " |\n"
+		<<< "| Classes           | " <<< classes <<< " |\n"
+		<<< "| Derivations       | " <<< derives <<< " |\n"
+		<<< "| Syntax constructs | " <<< syntaxs <<< " |\n"
+		<<< "+-------------------+-------+\n"
 	where
-		[modules,funs,types,classes,derives:_]
+		[modules,funs,types,classes,derives,syntaxs:_]
 			= map (pad 5)
 				[ moduleCount db
 				, functionCount db
 				, typeCount db
 				, classCount db
 				, deriveCount db
+				, syntaxCount db
 				]
 		pad n i = {' ' \\ _ <- [0..n-size (toString i)-1]} +++ toString i
 

--- a/frontend/api.js
+++ b/frontend/api.js
@@ -222,6 +222,8 @@ function makeExampleList(examples) {
 }
 
 function markupDocumentation(doc) {
+	doc = doc.replace(/\n\n/g, '<br class="parbreak"/>');
+	doc = doc.replace(/\n\s*-\s*/g, '<br/>- ');
 	doc = doc.replace(/{{`([^`}]+)`}}/g, '`{{$1}}`');
 	doc = doc.replace(/`([^`]+)`/g, '<code>$1</code>');
 	doc = doc.replace(/{{([^}]+)}}/g, function (m,c) {
@@ -512,8 +514,6 @@ function getResults(str, libs, include_builtins, include_core, include_apps, pag
 						highlightFunction('import ' + basic['modul']));
 
 			case 'SyntaxResult':
-				meta.push(markupDocumentation(extra['syntax_description'].replace(/\n/g, '<br/>')));
-
 				var urls = '';
 				if (extra['syntax_doc_location'].length > 0) {
 					urls += ' (';

--- a/frontend/api.js
+++ b/frontend/api.js
@@ -128,9 +128,7 @@ function makeParametersHTML(name, params) {
 }
 
 function makeLocationUrl(loc) {
-	var dclUrl =
-		'src?lib=' + encodeURIComponent(loc[0]) +
-		'#' + encodeURIComponent(loc[1]);
+	var dclUrl = 'src#' + encodeURIComponent(loc[0] + '.' + loc[1]);
 	var iclUrl = dclUrl + ';icl';
 
 	if (loc[2].length > 1)
@@ -324,9 +322,7 @@ function getResults(str, libs, include_builtins, include_core, include_apps, pag
 	}
 
 	var makeGenericResultHTML = function (basic, meta, hidden, code) {
-		var dclUrl =
-			'src?lib=' + encodeURIComponent(basic['library']) +
-			'#' + encodeURIComponent(basic['modul']);
+		var dclUrl = 'src#' + encodeURIComponent(basic['library'] + '.' + basic['modul']);
 		var iclUrl = dclUrl + ';icl';
 		var dclLine = '';
 		var iclLine = '';

--- a/frontend/api.js
+++ b/frontend/api.js
@@ -183,11 +183,14 @@ function makeRequiredContext(context) {
 }
 
 function highlightExample(example) {
-	if ('cleanjs_start' in example) {
-		return window['highlight' + example.cleanjs_type](
+	var f = 'highlight' + example.cleanjs_type;
+	if (!(f in window)) {
+		return example.example;
+	} else if ('cleanjs_start' in example) {
+		return window[f](
 				example.example, highlightCallback, example.cleanjs_start);
 	} else {
-		return window['highlight' + example.cleanjs_type](
+		return window[f](
 				example.example, highlightCallback);
 	}
 }
@@ -210,7 +213,12 @@ function highlightSyntaxConstruct(elem) {
 			[/(\w+)/,    ['keyword optional']],
 			[/(\S)/,     ['punctuation']]
 		]
-	}, elem, highlightCallback);
+	}, elem, function (span, cls, str) {
+		if (str == '...')
+			return span.replace('...', '&#8230;');
+		else
+			return span;
+	});
 }
 
 function makeExampleList(examples) {

--- a/frontend/api.js
+++ b/frontend/api.js
@@ -343,7 +343,7 @@ function getResults(str, libs, include_builtins, include_core, include_apps, pag
 				'<a href="' + iclUrl + '" target="_blank">icl' + iclLine + '</a>)';
 
 		if ('builtin' in basic && basic['builtin'])
-			basicText = [['Clean core. The actual implementation may differ. For documentation, see the Clean language report.']];
+			basicText = [['Clean core. The actual implementation may differ.']];
 
 		var toggler = '';
 		if (hidden.length > 0) {
@@ -369,6 +369,21 @@ function getResults(str, libs, include_builtins, include_core, include_apps, pag
 
 		var meta = [];
 		var hidden = [];
+
+		if ('langrep_documentation' in basic &&
+				basic['langrep_documentation'].length > 0) {
+			var doc = 'See the language report: ';
+			for (var i in basic['langrep_documentation']) {
+				var loc = basic['langrep_documentation'][i];
+				if (i != 0)
+					doc += '; ';
+				doc += '<a target="_blank" ' +
+					'href="/doc/#' + loc.clr_file + ';jump=' + loc.clr_heading + '">' +
+					loc.clr_section + '</a>';
+			}
+			doc += '.';
+			meta.push(doc);
+		}
 
 		if ('documentation' in basic)
 			meta.push(markupDocumentation(basic['documentation']));
@@ -514,20 +529,6 @@ function getResults(str, libs, include_builtins, include_core, include_apps, pag
 						highlightFunction('import ' + basic['modul']));
 
 			case 'SyntaxResult':
-				var urls = '';
-				if (extra['syntax_doc_location'].length > 0) {
-					urls += ' (';
-					for (var i in extra['syntax_doc_location']) {
-						var loc = extra['syntax_doc_location'][i][1];
-						if (i != 0)
-							urls += '; ';
-						urls += '<a target="_blank" ' +
-							'href="/doc/#' + loc.clr_file + ';jump=' + loc.clr_heading + '">' +
-							'Section ' + loc.clr_section + ' of the Language report v' + loc.clr_version + '</a>';
-					}
-					urls += ')';
-				}
-
 				var toggler = '';
 				if (extra['syntax_examples'].length > 0) {
 					toggler = '<div class="toggler" title="More details" onclick="toggle(this)">' +

--- a/frontend/api.js
+++ b/frontend/api.js
@@ -542,7 +542,7 @@ function getResults(str, libs, include_builtins, include_core, include_apps, pag
 				}
 
 				return '<div class="result">' +
-						'<div class="result-basic">Clean syntax: ' + extra['syntax_title'] + urls + '</div>' +
+						'<div class="result-basic">Clean syntax: ' + extra['syntax_title'] + '</div>' +
 						'<div class="result-extra">' + meta.join('<br/>') + '</div>' +
 						'<div class="result-extra toggle-container">' +
 							toggler +

--- a/frontend/browser.js
+++ b/frontend/browser.js
@@ -89,13 +89,12 @@ Element.prototype.browser = function(opts) {
 	return {
 		state: state,
 		triggerChange: triggerChange,
-		setPath: function(path) {
+		openPath: function(path) {
 			var old = root.getElementsByClassName('active');
 			for (var i = 0; i < old.length; i++)
 				old[i].classList.remove('active');
 
 			var e = root;
-			console.log(path);
 			for (var i = 0; i < path.length && 'childNodes' in e; i++) {
 				var children = e.childNodes;
 				for (var k = 0; k < children.length; k++) {
@@ -109,6 +108,15 @@ Element.prototype.browser = function(opts) {
 						break;
 					}
 				}
+			}
+		},
+		openTo: function(elem) {
+			var path = [];
+			elem.classList.add('active');
+			while (elem != root && elem != null) {
+				if (elem.classList.contains('toggle-container'))
+					toggle(elem, true);
+				elem = elem.parentNode;
 			}
 		},
 		open: function() {

--- a/frontend/browser.js
+++ b/frontend/browser.js
@@ -102,7 +102,7 @@ Element.prototype.browser = function(opts) {
 						if (i < path.length - 1) {
 							toggle(children[k]);
 							e = children[k].childNodes[1];
-						} else {
+						} else if (!children[k].classList.contains('directory')) {
 							children[k].classList.add('active');
 						}
 						break;
@@ -111,8 +111,11 @@ Element.prototype.browser = function(opts) {
 			}
 		},
 		openTo: function(elem) {
+			if (elem == null)
+				return;
 			var path = [];
-			elem.classList.add('active');
+			if (!elem.classList.contains('directory'))
+				elem.classList.add('active');
 			while (elem != root && elem != null) {
 				if (elem.classList.contains('toggle-container'))
 					toggle(elem, true);

--- a/frontend/common.css
+++ b/frontend/common.css
@@ -1,3 +1,13 @@
+body.framelike {
+	margin: 0;
+	overflow: hidden;
+}
+
+body.framelike #logo {
+	margin-bottom: 1em;
+	max-width: 100%;
+}
+
 pre {
 	-moz-tab-size: 4;
 	-o-tab-size: 4;
@@ -31,4 +41,68 @@ td, th {
 
 #share-link {
 	display: none;
+}
+
+.browser-header {
+	margin-bottom: 0.2em;
+}
+
+.browser-item {
+	cursor: pointer;
+	font-weight: normal;
+}
+
+.browser-item.active {
+	font-style: italic;
+}
+
+.browser-item.directory .browser {
+	background-color: rgba(0, 0, 0, 0.05);
+	padding-left: 1em;
+}
+
+.browser-item {
+	padding-left: 1em;
+	text-indent: -1em;
+}
+
+#sidebar {
+	float: left;
+	overflow: auto;
+	padding: 10px 1em;
+	width: 15em;
+}
+
+#sidebar h3 {
+	margin-top: .2em;
+}
+
+
+#viewer {
+	margin-left: 16em;
+	overflow: auto;
+}
+
+#viewer #loading {
+	font-style: italic;
+	margin-top: 8em;
+	text-align: center;
+}
+
+@media (max-width: 800px) {
+	body {
+		overflow: auto;
+	}
+
+	#sidebar {
+		float: none;
+		overflow: initial;
+		width: calc(100% - 2em);
+	}
+
+	#viewer {
+		clear: both;
+		margin-left: 0;
+		overflow: initial;
+	}
 }

--- a/frontend/common.js
+++ b/frontend/common.js
@@ -21,8 +21,10 @@ function toggle(toggler, open) {
 
 		if (typeof open == 'undefined')
 			toggleElement(es[i], 'toggle-visible');
+		else if (open)
+			es[i].classList.add('toggle-visible');
 		else
-			es[i].style.display = open ? 'block' : 'none';
+			es[i].classList.remove('toggle-visible');
 	}
 
 	var icons = e.getElementsByClassName('toggle-icon');

--- a/frontend/doc/CleanRep.2.2.css
+++ b/frontend/doc/CleanRep.2.2.css
@@ -1,0 +1,1 @@
+/opt/clean/doc/CleanLangRep/CleanRep.2.2.css

--- a/frontend/doc/CleanRep.2.2_files
+++ b/frontend/doc/CleanRep.2.2_files
@@ -1,0 +1,1 @@
+/opt/clean/doc/CleanLangRep/CleanRep.2.2_files/

--- a/frontend/doc/contents.php
+++ b/frontend/doc/contents.php
@@ -68,7 +68,7 @@ class Toc {
 						$child->title . '</span></div>';
 			} else {
 				echo '<div class="browser-item directory toggle-container" id="doc-' . $child->link . '">' .
-						'<span class="toggler" onclick="toggle(this)">' .
+						'<span class="toggler">' .
 							'<span class="toggle-icon">&#x229e</span>' .
 							'<span class="title">' . $child->title . '</span></span>';
 				$child->printTree();

--- a/frontend/doc/contents.php
+++ b/frontend/doc/contents.php
@@ -1,0 +1,87 @@
+<?php
+define('CLEANHOME', '/opt/clean');
+
+$dom = new DOMDocument;
+$dom->loadHTMLFile(CLEANHOME . '/doc/CleanLangRep/CleanRep.2.2_1.htm');
+
+function readContentsLevel($dom, $level) {
+
+}
+
+function isToc($class) {
+	return preg_match('/^MsoToc\d$/', $class) === 1;
+}
+
+function cleanToc($name) {
+	$name = preg_replace(['/[\r\x80-\xff]+/', '/\n/'], ['', ' '], $name);
+	$matches = [];
+	if (preg_match_all('/^([\d\.]+)?\s*(.+?)\s+[iv\d]+$/', $name, $matches) === 1)
+		return [
+			'index' => $matches[1][0],
+			'title' => preg_replace('/Chapter \d+\s+/', '', $matches[2][0]),
+		];
+	else
+		return null;
+}
+
+$toc = [];
+foreach ($dom->getElementsByTagName('p') as $p) {
+	if (isToc($p->getAttribute('class'))) {
+		$elem = cleanToc($p->textContent);
+		if ($elem != null) {
+			$elem['level'] = (int) str_replace('MsoToc', '', $p->getAttribute('class'));
+			$elem['link'] = str_replace('#', ';jump=', $p->getElementsByTagName('a')[0]->getAttribute('href'));
+			$toc[] = $elem;
+		}
+	}
+}
+
+class Toc {
+	protected $title = '';
+	protected $link = '';
+	protected $ref = null;
+	protected $children = [];
+
+	public static function factory($level, $elems) {
+		$toc = new Toc;
+		while (count($elems) > 0) {
+			$elem = array_shift($elems);
+			if ($elem['level'] <= $level) {
+				$deeper = [];
+				while ($elems[0]['level'] > $level)
+					$deeper[] = array_shift($elems);
+				$child = Toc::factory($level + 1, $deeper);
+				$child->title = $elem['title'];
+				$child->link = $elem['link'];
+				$toc->children[] = $child;
+			}
+		}
+		return $toc;
+	}
+
+	public function printTree() {
+		echo '<div class="browser togglee">';
+		foreach ($this->children as $child) {
+			if ($child->isLeaf()) {
+				echo '<div class="browser-item module" onclick="loadModule(this)" ' .
+							'data-module="' . $child->link . '">' . $child->title . '</span>' .
+					'</div>';
+			} else {
+				echo '<div class="browser-item directory toggle-container">' .
+						'<span class="toggler" onclick="toggle(this)">' .
+							'<span class="toggle-icon">&#x229e</span>' .
+							'<span class="title">' . $child->title . '</span></span>';
+				$child->printTree();
+				echo '</div>';
+			}
+		}
+		echo '</div>';
+	}
+
+	public function isLeaf() {
+		return count($this->children) == 0;
+	}
+}
+
+$toc = Toc::factory(1, $toc);
+$toc->printTree();

--- a/frontend/doc/contents.php
+++ b/frontend/doc/contents.php
@@ -63,11 +63,11 @@ class Toc {
 		echo '<div class="browser togglee">';
 		foreach ($this->children as $child) {
 			if ($child->isLeaf()) {
-				echo '<div class="browser-item module" id="' . $child->link .
+				echo '<div class="browser-item module" id="doc-' . $child->link .
 						'" data-name="' . $child->link . '">' .
 						$child->title . '</span></div>';
 			} else {
-				echo '<div class="browser-item directory toggle-container">' .
+				echo '<div class="browser-item directory toggle-container" id="doc-' . $child->link . '">' .
 						'<span class="toggler" onclick="toggle(this)">' .
 							'<span class="toggle-icon">&#x229e</span>' .
 							'<span class="title">' . $child->title . '</span></span>';

--- a/frontend/doc/contents.php
+++ b/frontend/doc/contents.php
@@ -63,9 +63,9 @@ class Toc {
 		echo '<div class="browser togglee">';
 		foreach ($this->children as $child) {
 			if ($child->isLeaf()) {
-				echo '<div class="browser-item module" onclick="loadModule(this)" ' .
-							'data-module="' . $child->link . '">' . $child->title . '</span>' .
-					'</div>';
+				echo '<div class="browser-item module" id="' . $child->link .
+						'" data-name="' . $child->link . '">' .
+						$child->title . '</span></div>';
 			} else {
 				echo '<div class="browser-item directory toggle-container">' .
 						'<span class="toggler" onclick="toggle(this)">' .

--- a/frontend/doc/doc.js
+++ b/frontend/doc/doc.js
@@ -32,6 +32,7 @@ window.onload = function() {
 		},
 		viewer: viewer,
 		onLoad: function(state) {
+			viewer.innerHTML += '<br/>';
 			if (state.jump != null) {
 				var l = document.getElementsByName(state.jump)[0].documentOffsetTop();
 				viewer.scrollTop = l - window.innerHeight/8;
@@ -47,8 +48,8 @@ window.onload = function() {
 	var sidebar = document.getElementById('sidebar');
 	var viewer = document.getElementById('viewer');
 	if (window.innerWidth > 800) {
-		var height = window.innerHeight;
-		sidebar.style.height = (height - 20) + 'px';
+		var height = window.innerHeight - 20;
+		sidebar.style.height = height + 'px';
 		viewer.style.height = height + 'px';
 	}
 

--- a/frontend/doc/doc.js
+++ b/frontend/doc/doc.js
@@ -19,7 +19,7 @@ window.onload = function() {
 				if (hashelems[i].substring(0,5) == 'jump=')
 					this.state.jump = hashelems[i].substring(5);
 			this.newState();
-			browser.openTo(document.getElementById(hash));
+			browser.openTo(document.getElementById('doc-' + hash));
 		},
 		newState: function () {
 			var hash = this.state.loc;
@@ -51,4 +51,9 @@ window.onload = function() {
 		sidebar.style.height = (height - 20) + 'px';
 		viewer.style.height = height + 'px';
 	}
-}
+
+	window.onhashchange = function () {
+		browser.open();
+		browser.triggerChange();
+	};
+};

--- a/frontend/doc/doc.js
+++ b/frontend/doc/doc.js
@@ -34,7 +34,7 @@ window.onload = function() {
 		onLoad: function(state) {
 			if (state.jump != null) {
 				var l = document.getElementsByName(state.jump)[0].documentOffsetTop();
-				viewer.scrollTo(0, l - window.innerHeight/4);
+				viewer.scrollTo(0, l - window.innerHeight/8);
 			}
 		},
 		state: {

--- a/frontend/doc/doc.js
+++ b/frontend/doc/doc.js
@@ -34,7 +34,7 @@ window.onload = function() {
 		onLoad: function(state) {
 			if (state.jump != null) {
 				var l = document.getElementsByName(state.jump)[0].documentOffsetTop();
-				viewer.scrollTo(0, l - window.innerHeight/8);
+				viewer.scrollTop = l - window.innerHeight/8;
 			}
 		},
 		state: {

--- a/frontend/doc/doc.js
+++ b/frontend/doc/doc.js
@@ -1,0 +1,54 @@
+window.onload = function() {
+	var viewer = document.getElementById('viewer');
+
+	var browser = document.getElementsByClassName('browser')[0].browser({
+		newPath: function (path) {
+			path = path[0].split(';');
+			this.state.loc = path[0];
+			this.state.jump = null;
+			for (var i = 1; i < path.length; i++)
+				if (path[i].substring(0,5) == 'jump=')
+					this.state.jump = path[i].substring(5);
+			this.newState();
+		},
+		newHash: function (hash) {
+			var hashelems = hash.split(';');
+			this.state.loc = hashelems[0];
+			this.state.jump = null;
+			for (var i = 1; i < hashelems.length; i++)
+				if (hashelems[i].substring(0,5) == 'jump=')
+					this.state.jump = hashelems[i].substring(5);
+			this.newState();
+			browser.openTo(document.getElementById(hash));
+		},
+		newState: function () {
+			var hash = this.state.loc;
+			if (this.state.jump != null)
+				hash += ';jump=' + this.state.jump;
+			document.location.hash = '#' + hash;
+		},
+		getUrl: function () {
+			return 'src.php?loc=' + encodeURIComponent(this.state.loc);
+		},
+		viewer: viewer,
+		onLoad: function(state) {
+			if (state.jump != null) {
+				var l = document.getElementsByName(state.jump)[0].documentOffsetTop();
+				viewer.scrollTo(0, l - window.innerHeight/4);
+			}
+		},
+		state: {
+			jump: false
+		}
+	});
+	browser.open();
+	browser.triggerChange();
+
+	var sidebar = document.getElementById('sidebar');
+	var viewer = document.getElementById('viewer');
+	if (window.innerWidth > 800) {
+		var height = window.innerHeight;
+		sidebar.style.height = (height - 20) + 'px';
+		viewer.style.height = height + 'px';
+	}
+}

--- a/frontend/doc/index.php
+++ b/frontend/doc/index.php
@@ -13,7 +13,7 @@
 	<link rel="stylesheet" href="../src/view.css" type="text/css"/>
 	<style type="text/css">
 		#viewer {
-			padding: 1em;
+			padding: 10px;
 		}
 
 		#viewer p {

--- a/frontend/doc/index.php
+++ b/frontend/doc/index.php
@@ -7,10 +7,15 @@
 	<meta name="description" content="Cloogle is the unofficial Clean language search engine"/>
 	<meta name="keywords" content="Clean,Clean language,Concurrent Clean,search,functions,search engine,programming language,clean platform,iTasks,cloogle,hoogle"/>
 	<script src="../common.js" type="text/javascript" defer="defer"></script>
-	<script src="../src/view.js" type="text/javascript" defer="defer"></script>
+	<script src="../browser.js" type="text/javascript" defer="defer"></script>
+	<script src="doc.js" type="text/javascript" defer="defer"></script>
 	<link rel="stylesheet" href="../common.css" type="text/css"/>
 	<link rel="stylesheet" href="../src/view.css" type="text/css"/>
 	<style type="text/css">
+		#viewer {
+			padding: 1em;
+		}
+
 		.Heading1Chapter img, .Newchapter img {
 			display: none;
 		}

--- a/frontend/doc/index.php
+++ b/frontend/doc/index.php
@@ -29,6 +29,10 @@
 		.Heading1Chapter img, .Newchapter img {
 			display: none;
 		}
+
+		a:visited {
+			color: blue !important;
+		}
 	</style>
 </head>
 <body>

--- a/frontend/doc/index.php
+++ b/frontend/doc/index.php
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Documentation browser</title>
+	<meta http-equiv="Content-Type" content="text/html; charset=windows-1252"/>
+	<meta name="viewport" content="width=device-width, initial-scale=1"/>
+	<meta name="description" content="Cloogle is the unofficial Clean language search engine"/>
+	<meta name="keywords" content="Clean,Clean language,Concurrent Clean,search,functions,search engine,programming language,clean platform,iTasks,cloogle,hoogle"/>
+	<script src="../common.js" type="text/javascript" defer="defer"></script>
+	<script src="../src/view.js" type="text/javascript" defer="defer"></script>
+	<link rel="stylesheet" href="../common.css" type="text/css"/>
+	<link rel="stylesheet" href="../src/view.css" type="text/css"/>
+	<style type="text/css">
+		.Heading1Chapter img, .Newchapter img {
+			display: none;
+		}
+	</style>
+</head>
+<body>
+	<div id="sidebar">
+		<a href="/"><img id="logo" src="../logo.png" alt="Cloogle logo"/></a>
+		<h3>Documentation browser</h3>
+		<hr/>
+		<?php include_once('contents.php'); ?>
+	</div><div id="viewer">
+		<?php include_once('src.php'); ?>
+	</div>
+</body>
+</html>

--- a/frontend/doc/index.php
+++ b/frontend/doc/index.php
@@ -16,6 +16,10 @@
 			padding: 1em;
 		}
 
+		#sidebar {
+			min-width: 300px;
+		}
+
 		#sidebar h3 {
 			background: none;
 			font-family: serif;
@@ -32,6 +36,11 @@
 
 		a:visited {
 			color: blue !important;
+		}
+
+		.browser-item {
+			padding-left: 1em;
+			text-indent: -1em;
 		}
 	</style>
 </head>

--- a/frontend/doc/index.php
+++ b/frontend/doc/index.php
@@ -16,6 +16,16 @@
 			padding: 1em;
 		}
 
+		#sidebar h3 {
+			background: none;
+			font-family: serif;
+			font-size: 1.17em;
+			font-weight: bold;
+			line-height: 22px;
+			margin-bottom: 17.55px;
+			margin-left: 0;
+		}
+
 		.Heading1Chapter img, .Newchapter img {
 			display: none;
 		}

--- a/frontend/doc/index.php
+++ b/frontend/doc/index.php
@@ -10,7 +10,6 @@
 	<script src="../browser.js" type="text/javascript" defer="defer"></script>
 	<script src="doc.js" type="text/javascript" defer="defer"></script>
 	<link rel="stylesheet" href="../common.css" type="text/css"/>
-	<link rel="stylesheet" href="../src/view.css" type="text/css"/>
 	<style type="text/css">
 		#viewer {
 			padding: 10px;
@@ -41,14 +40,9 @@
 		a:visited {
 			color: blue !important;
 		}
-
-		.browser-item {
-			padding-left: 1em;
-			text-indent: -1em;
-		}
 	</style>
 </head>
-<body>
+<body class="framelike">
 	<div id="sidebar">
 		<a href="/"><img id="logo" src="../logo.png" alt="Cloogle logo"/></a>
 		<h3>Documentation browser</h3>

--- a/frontend/doc/index.php
+++ b/frontend/doc/index.php
@@ -16,6 +16,10 @@
 			padding: 1em;
 		}
 
+		#viewer p {
+			position: relative; /* For images, e.g. in 3.5.2 */
+		}
+
 		#sidebar {
 			min-width: 300px;
 		}

--- a/frontend/doc/index.php
+++ b/frontend/doc/index.php
@@ -48,6 +48,9 @@
 		<h3>Documentation browser</h3>
 		<hr/>
 		<?php include_once('contents.php'); ?>
+		<hr/>
+		The content of the language report is copyright &copy; 1987-2001, Hilt B.V., The Netherlands.
+		See the <a href="#CleanRep.2.2_2.htm;jump=_Toc311797972">copyright notice</a>.
 	</div><div id="viewer">
 		<?php include_once('src.php'); ?>
 	</div>

--- a/frontend/doc/square_8.png
+++ b/frontend/doc/square_8.png
@@ -1,0 +1,1 @@
+/opt/clean/doc/CleanLangRep/square_8.png

--- a/frontend/doc/src.php
+++ b/frontend/doc/src.php
@@ -1,7 +1,7 @@
 <?php
 define('CLEANHOME', '/opt/clean');
 
-$loc = isset($_REQUEST['mod']) ? $_REQUEST['mod'] : 'CleanRep.2.2_1.htm;jump=_Toc311797959';
+$loc = $_REQUEST['loc'] ?: 'CleanRep.2.2_1.htm;jump=_Toc311797959';
 $loc = preg_replace('/\.\.+/', '.', $loc);
 $loc = preg_replace('/[^\w\d.;=]+/', '', $loc);
 

--- a/frontend/doc/src.php
+++ b/frontend/doc/src.php
@@ -13,12 +13,16 @@ $doc->loadHTMLFile(CLEANHOME . '/doc/CleanLangRep/' . $file);
 
 function transformLink($orgfile, $a) {
 	$href = $a->getAttribute('href');
-	$match = [];
-	if (preg_match('/^(.*)#(.*)$/', $href, $match) == 0)
-		$a->setAttribute('href', '#' . $href);
-	$file = $match[1] != '' ? $match[1] : $orgfile;
-	$hash = $match[2];
-	$a->setAttribute('href', '#' . $file . ';jump=' . $hash);
+	if (substr($href, 0, 4) == 'http') {
+		$a->setAttribute('target', '_blank');
+	} else {
+		$match = [];
+		if (preg_match('/^(.*)#(.*)$/', $href, $match) == 0)
+			$a->setAttribute('href', '#' . $href);
+		$file = $match[1] != '' ? $match[1] : $orgfile;
+		$hash = $match[2];
+		$a->setAttribute('href', '#' . $file . ';jump=' . $hash);
+	}
 }
 
 foreach ($doc->getElementsByTagName('a') as $a) {

--- a/frontend/doc/src.php
+++ b/frontend/doc/src.php
@@ -1,0 +1,28 @@
+<?php
+define('CLEANHOME', '/opt/clean');
+
+$loc = isset($_REQUEST['mod']) ? $_REQUEST['mod'] : 'CleanRep.2.2_1.htm;jump=_Toc311797959';
+$loc = preg_replace('/\.\.+/', '.', $loc);
+$loc = preg_replace('/[^\w\d.;=]+/', '', $loc);
+
+$match = [];
+$file = preg_match('/(.+);jump=(.+)/', $loc, $match) > 0 ? $file = $match[1] : $loc;
+
+$doc = new DOMDocument;
+$doc->loadHTMLFile(CLEANHOME . '/doc/CleanLangRep/' . $file);
+
+function transformLink($orgfile, $a) {
+	$href = $a->getAttribute('href');
+	$match = [];
+	if (preg_match('/^(.*)#(.*)$/', $href, $match) == 0)
+		$a->setAttribute('href', '#' . $href);
+	$file = $match[1] != '' ? $match[1] : $orgfile;
+	$hash = $match[2];
+	$a->setAttribute('href', '#' . $file . ';jump=' . $hash);
+}
+
+foreach ($doc->getElementsByTagName('a') as $a) {
+	transformLink($file, $a);
+}
+
+echo $doc->saveHtml($doc);

--- a/frontend/frontend.css
+++ b/frontend/frontend.css
@@ -203,6 +203,7 @@ div.visible {
 }
 
 .example {
+	font-size: initial;
 	margin: .5em;
 }
 

--- a/frontend/frontend.css
+++ b/frontend/frontend.css
@@ -16,6 +16,10 @@ a {
 	color: #26c;
 }
 
+br.parbreak {
+	margin-bottom: .5em;
+}
+
 #header {
 	margin-top: 10%;
 	text-align: center;

--- a/frontend/frontend.css
+++ b/frontend/frontend.css
@@ -198,6 +198,18 @@ div.visible {
 	padding-left: 1em;
 }
 
+.examples {
+	padding-bottom: .5em;
+}
+
+.example {
+	margin: .5em;
+}
+
+.keyword.optional {
+	color: #777;
+}
+
 @media (max-width: 600px) {
 	#header.result-view > * {
 		display: block;

--- a/frontend/src/index.php
+++ b/frontend/src/index.php
@@ -12,7 +12,7 @@
 	<link rel="stylesheet" href="../common.css" type="text/css"/>
 	<link rel="stylesheet" href="view.css" type="text/css"/>
 </head>
-<body>
+<body class="framelike">
 	<div id="sidebar">
 		<a href="/"><img id="logo" src="../logo.png" alt="Cloogle logo"/></a>
 		<h3>Library browser</h3>

--- a/frontend/src/lib.php
+++ b/frontend/src/lib.php
@@ -1,5 +1,6 @@
 <?php
 define('CLEANHOME', '/opt/clean');
+define('CLEANLIB', CLEANHOME . '/lib');
 
 $lib = isset($_GET['lib']) ? $_GET['lib'] : 'StdEnv';
 $lib = preg_replace('/[^\\w\\/\\-]/', '', $lib);
@@ -70,13 +71,55 @@ function makeBrowser($dir, $basemodule) {
 
 	foreach ($elems['modules'] as $m) {
 		$fullm = $basemodule . $m;
-		echo '<div class="browser-item module" data-name="' . $m . '">' . $m . '</span>' .
-			'</div>';
+		echo '<div class="browser-item module" data-name="' . $m . '">' . $m . '</div>';
 	}
 
 	echo '</div>';
 }
 
-$dname = CLEANHOME . '/lib';
+$alllibs = [
+	'Clean 2.4' => [
+		'StdEnv',
+		'ArgEnv',
+		'Directory',
+		'Dynamics',
+		'Gast',
+		'Generics',
+		'MersenneTwister',
+		'StdLib',
+		'TCPIP',
+	],
+	'Official' => [
+		'GraphCopy',
+		'ObjectIO',
+		'Platform',
+		'Sapl',
+		'iTasks',
+	],
+	'Miscellaneous' => [
+		'CleanInotify',
+		'CleanPrettyPrint',
+		'CleanSerial',
+		'CleanSnappy',
+		'CleanTypeUnifier',
+		'Cloogle',
+		'SoccerFun',
+		'clean-compiler',
+		'clean-ide',
+		'libcloogle',
+	]
+];
 
-makeBrowser($dname, '');
+echo '<div class="browser">';
+foreach ($alllibs as $group => $libs) {
+	echo '<h4 class="browser-header">' . $group . '</h4>';
+	foreach ($libs as $lib) {
+		echo '<div class="browser-item directory toggle-container" data-name="' . $lib . '">' .
+				'<span class="toggler">' .
+					'<span class="toggle-icon">&#x229e</span>' .
+					'<span class="title">' . $lib . '</span></span>';
+		makeBrowser(CLEANLIB . '/' . $lib, '');
+		echo '</div>';
+	}
+}
+echo '</div>';

--- a/frontend/src/view.css
+++ b/frontend/src/view.css
@@ -72,82 +72,11 @@
 .highlighttable .vm { color: #19177C } /* Name.Variable.Magic */
 .highlighttable .il { color: #666666 } /* Literal.Number.Integer.Long */
 
-body {
-	margin: 0;
-	overflow: hidden;
-}
-
-#sidebar {
-	float: left;
-	overflow: auto;
-	padding: 10px 1em;
-	width: 15em;
-}
-
-#sidebar h3 {
-	margin-top: .2em;
-}
-
-#logo {
-	margin-bottom: 1em;
-	max-width: 100%;
-}
-
-#select-lib {
-	margin-bottom: .8em;
-}
-
 #share-button {
 	margin-top: .8em;
 }
 
-#viewer {
-	margin-left: 16em;
-	overflow: auto;
-}
-
-#viewer #loading {
-	font-style: italic;
-	margin-top: 8em;
-	text-align: center;
-}
-
-.browser-item {
+.linenodiv .special {
 	cursor: pointer;
-	font-weight: normal;
-}
-
-.browser-item.directory {
-	font-weight: bold;
-}
-
-.browser-item.active {
-	font-style: italic;
-}
-
-.browser-item.directory .browser {
-	background-color: rgba(0, 0, 0, 0.05);
-	padding-left: 1em;
-}
-
-@media (max-width: 800px) {
-	body {
-		overflow: auto;
-	}
-
-	#sidebar {
-		float: none;
-		overflow: initial;
-		width: calc(100% - 2em);
-	}
-
-	#viewer {
-		clear: both;
-		margin-left: 0;
-		overflow: initial;
-	}
-}
-
-.special {
-	cursor: pointer;
+	padding-left: .8em;
 }

--- a/frontend/src/view.js
+++ b/frontend/src/view.js
@@ -74,7 +74,7 @@ window.onload = function() {
 					this.state.line = hashelems[i].substring(5);
 			}
 
-			browser.setPath(this.state.mod.split('.'));
+			browser.openPath(this.state.mod.split('.'));
 		},
 		newState: function () {
 			var hash = this.state.mod;

--- a/frontend/src/view.js
+++ b/frontend/src/view.js
@@ -20,24 +20,33 @@ function loadModule(elem) {
 
 	viewer.innerHTML = '<p id="loading">Loading...</p>';
 
-	var url = 'src.php';
-	url += '?lib=' + libselect.value;
+	var url = 'src.php?';
+	if (libselect != null)
+		url += 'lib=' + libselect.value + '&';
 	if (curmod != '')
-		url += '&mod=' + curmod;
-	if (icl.checked)
-		url += '&icl';
+		url += 'mod=' + curmod + '&';
+	if (icl != null && icl.checked)
+		url += 'icl';
 	var hashelems = decodeURIComponent(window.location.hash.substring(1)).split(';');
-	for (var i in hashelems)
+
+	var jump = line != null ? 'line-' + line : null;
+	for (var i in hashelems) {
 		if (hashelems[i].substring(0,5) == 'line=')
 			url += '&line=' + hashelems[i].substring(5);
+		if (hashelems[i].substring(0,5) == 'jump=')
+			jump = hashelems[i].substring(5);
+	}
 
 	var xmlHttp = new XMLHttpRequest();
 	xmlHttp.onreadystatechange = function() { 
 		if (xmlHttp.readyState == 4 && xmlHttp.status == 200) {
 			viewer.innerHTML = xmlHttp.response;
 
-			if (line != null)
-				document.getElementById('line-' + line).scrollIntoView(true);
+			console.log(jump);
+			if (jump != null) {
+				var elem = document.getElementById(jump) || document.getElementsByName(jump)[0];
+				elem.scrollIntoView(true);
+			}
 
 			var linenos = document.getElementsByClassName('special');
 			for (var i = 0; i < linenos.length; i++) {
@@ -77,7 +86,7 @@ function updateLibraryPanel() {
 
 function updateHash() {
 	var newhash = curmod;
-	if (icl.checked)
+	if (icl != null && icl.checked)
 		newhash += ';icl';
 	if (line != null)
 		newhash += ';line=' + line;
@@ -111,9 +120,11 @@ function selectLine(elem) {
 }
 
 function restoreShareUI() {
-	share_button.disabled = false;
-	share_button.type = 'button';
-	share_button.value = 'Share';
+	if (share_button != null) {
+		share_button.disabled = false;
+		share_button.type = 'button';
+		share_button.value = 'Share';
+	}
 }
 
 function shareButtonClick() {
@@ -138,7 +149,7 @@ window.onhashchange = function() {
 	} else {
 		var elems = decodeURIComponent(window.location.hash.substring(1)).split(';');
 		curmod = elems[0];
-		icl.checked = elems.indexOf('icl') != -1;
+		if (icl != null) icl.checked = elems.indexOf('icl') != -1;
 		for (var i in elems)
 			if (elems[i].substring(0,5) == 'line=')
 				line = elems[i].substring(5);
@@ -158,11 +169,11 @@ window.onload = function () {
 		viewer.style.height = height + 'px';
 	}
 
-	libselect.onchange = function() {
+	if (libselect != null) libselect.onchange = function() {
 		window.location.href = '?lib=' + this.value;
 	}
 
-	icl.onchange = function() {
+	if (icl != null) icl.onchange = function() {
 		line = null;
 		loadModule();
 	}

--- a/frontend/src/view.js
+++ b/frontend/src/view.js
@@ -94,11 +94,12 @@ window.onload = function() {
 		},
 		viewer: viewer,
 		onLoad: function(state) {
+			viewer.scrollLeft = 0;
 			if (state.line != null) {
 				var l = document.getElementById('line-' + state.line).documentOffsetTop();
-				viewer.scrollTo(0, l - window.innerHeight/4);
+				viewer.scrollTop = l - window.innerHeight/4;
 			} else {
-				viewer.scrollTo(0, 0);
+				viewer.scrollTop = 0;
 			}
 
 			bindLinenos();

--- a/frontend/src/view.js
+++ b/frontend/src/view.js
@@ -123,4 +123,4 @@ window.onload = function() {
 		sidebar.style.height = (height - 20) + 'px';
 		viewer.style.height = height + 'px';
 	}
-}
+};


### PR DESCRIPTION
Please let me merge, because the `search-syntax` branches on submodules have to be merged as well.

This adds:

- 35 searchable syntax constructs with short descriptions, language report links and examples (resolves #130)
- A documentation browser at `/doc`
- Some predefined types (lists, arrays, tuples)
- Some documentation and language report links on already existing predefined types, like `World`
- Functionality for simple markup in documentation, to link to other searches and to format code in `<code>` (see `Cloogle/README.md`)
- A fix for the autoscroll functionality on `/src` for Chromium

Changes:

- The library browser has lost the `<select>` for libraries and now has a big tree instead (see below). This made it easier to generalise the browser for use on `/doc` as well. An other advantage is that you can now easily browse multiple libraries at the same time.
- Following this, the `/src` URLs have changed, it would now be e.g. `#Platform.Data.Map` rather than `?lib=Platform#Data.Map`. That means that old URLs are now broken.

To be done (partially after merging this):

- [x] It would be better to split the libraries in the tree on the library browser up in the "Clean 2.4", "Official" and "Miscellaneous" categories.
- [x] In the documentation, some internal links don't work properly (the links from the tree work fine).
- [ ] In the documentation, it is not possible to navigate to umbrella sections. This should be possible.
- [x] Copyright notices for the documentation browser
- [x] Creating an annotated StdEnv to index where functions as `_from_to` have documentation to point to dotdot expressions.
- [x] clean.js needs to be extended to deal with some peculiarities; see the `TODO`s in `Builtins.icl`. This can go together with clean-cloogle/clean.js#1.

Not done for now are these syntax constructs, because they are very basic / very advanced or the construct has so many different meanings that it's not helpful to provide all. But they can be added:

***This list is now outdated. See #180.***

- [x] `=:` for newtypes
- [x] `=:` for the pattern check function
- [ ] `:` for uniqueness variables (`u:Int`)
- [ ] `*` for uniqueness
- [ ] `.` for uniqueness
- [ ] `[u<=v]` for uniqueness inequalities
- [ ] `|` for guards and type contexts
- [ ] `&` for type contexts (both in type contexts and on constructors)
- [ ] `,` for type contexts
- [x] `^` for type references in dynamic patterns
- [ ] `::` for function and type definitions
- [ ] `=` for function and type definitions
- [ ] `=` and `=>` to separate guards and alternative
- [ ] `->` and `=` to separate pattern and alternative in `case` expressions
- [ ] array comprehensions
- [ ] `special` for specialised class instances
- [x] <s>`export` for class instance exports</s> (this `TypeClassInstanceDef` in the language report seems to be outdated)
- [x] `foreign`, `ccall` and `stdcall` for foreign code exports
- [ ] `//` and `/* ... */` for comments

![2017-09-29-081725_230x746](https://user-images.githubusercontent.com/1202754/31003273-15ec47fc-a4ef-11e7-88f5-e72ded60c728.png)
