### PR TITLE
Scrolling; Fixes scrolling issue in source and coumentation view

### DIFF
--- a/frontend/common.css
+++ b/frontend/common.css
@@ -14,11 +14,11 @@ pre {
 }
 
 table {
-       border-spacing: 0;
+	border-spacing: 0;
 }
 
 td, th {
-       padding-right: 1em;
+	padding-right: 1em;
 }
 
 .banner {

--- a/frontend/common.css
+++ b/frontend/common.css
@@ -1,10 +1,9 @@
 body.framelike {
 	margin: 0;
-	overflow: hidden;
+	height: 100vh;
 }
 
 body.framelike #logo {
-	margin-bottom: 1em;
 	max-width: 100%;
 }
 
@@ -15,11 +14,11 @@ pre {
 }
 
 table {
-	border-spacing: 0;
+       border-spacing: 0;
 }
 
 td, th {
-	padding-right: 1em;
+       padding-right: 1em;
 }
 
 .banner {
@@ -95,24 +94,28 @@ td, th {
 
 #sidebar {
 	float: left;
-	overflow: auto;
-	padding: 10px 1em;
+	overflow: scroll;
 	width: 15em;
+	padding: 0 1em;
+	height: 100%;
 }
 
 #sidebar h3 {
 	margin-top: .2em;
 }
 
+#sidebar a, #sidebar h3 {
+	padding-left: .5em;
+}
 
 #viewer {
-	margin-left: 16em;
-	overflow: auto;
+	height: 100%;
+	overflow: scroll;
 }
 
 #viewer #loading {
 	font-style: italic;
-	margin-top: 8em;
+	padding-top: 8em;
 	text-align: center;
 }
 
@@ -121,13 +124,19 @@ td, th {
 		overflow: auto;
 	}
 
+	body.framelike {
+		overflow: auto;
+	}
+
 	#sidebar {
+		height: auto;
+		width: 100%;
 		float: none;
 		overflow: initial;
-		width: calc(100% - 2em);
 	}
 
 	#viewer {
+		height: auto;
 		clear: both;
 		margin-left: 0;
 		overflow: initial;

--- a/frontend/common.css
+++ b/frontend/common.css
@@ -69,6 +69,10 @@ td, th {
 	display: none;
 }
 
+.browser {
+	margin-bottom: 1em;
+}
+
 .browser-header {
 	margin-bottom: 0.2em;
 }
@@ -93,11 +97,12 @@ td, th {
 }
 
 #sidebar {
+	box-sizing: border-box;
 	float: left;
-	overflow: scroll;
-	width: 15em;
-	padding: 0 1em;
 	height: 100%;
+	overflow: auto;
+	padding: 1em;
+	width: 15em;
 }
 
 #sidebar h3 {
@@ -110,7 +115,7 @@ td, th {
 
 #viewer {
 	height: 100%;
-	overflow: scroll;
+	overflow: auto;
 }
 
 #viewer #loading {

--- a/frontend/src/view.js
+++ b/frontend/src/view.js
@@ -116,12 +116,4 @@ window.onload = function() {
 		browser.triggerChange();
 	};
 	icl.onchange();
-
-	var sidebar = document.getElementById('sidebar');
-	var viewer = document.getElementById('viewer');
-	if (window.innerWidth > 800) {
-		var height = window.innerHeight;
-		sidebar.style.height = (height - 20) + 'px';
-		viewer.style.height = height + 'px';
-	}
 };


### PR DESCRIPTION
Instead of calculating the height of the viewport in Javascript, use the `vh` measure instead. This also solves an issue where the browser would overlap with the viewer.